### PR TITLE
Hide the Purchase button until request is S32 approved

### DIFF
--- a/saas_app/internal_ops/forms.py
+++ b/saas_app/internal_ops/forms.py
@@ -106,8 +106,11 @@ class ViewS32RequestForm(ModelForm):
             ),
         )
         # append the Purchase Information button if the request is approved
-        if self.instance.status == "S32 approved" or self.instance.status == "Approuvé S32":
-                self.helper.layout[17] = Button (
+        if (
+            self.instance.status == "S32 approved"
+            or self.instance.status == "Approuvé S32"
+        ):
+            self.helper.layout[17] = Button(
                 "purchase",
                 _("Record Purchase Information"),
                 css_id="submit",

--- a/saas_app/internal_ops/forms.py
+++ b/saas_app/internal_ops/forms.py
@@ -86,6 +86,7 @@ class ViewS32RequestForm(ModelForm):
                 data_target="#request_info_modal",
                 data_dismiss="modal",
             ),
+            # hide the purchase button for now. It will be shown if the request is approved by an s32 approver.
             Button(
                 "purchase",
                 _("Record Purchase Information"),
@@ -94,6 +95,7 @@ class ViewS32RequestForm(ModelForm):
                 data_toggle="modal",
                 data_target="#purchase_modal",
                 data_dismiss="modal",
+                hidden=True,
             ),
             Button(
                 "cancel",
@@ -103,3 +105,14 @@ class ViewS32RequestForm(ModelForm):
                 onclick="history.back()",
             ),
         )
+        # append the Purchase Information button if the request is approved
+        if self.instance.status == "S32 approved" or self.instance.status == "Approuvé S32":
+                self.helper.layout[17] = Button (
+                "purchase",
+                _("Record Purchase Information"),
+                css_id="submit",
+                css_class="btn btn-primary btn-lg",
+                data_toggle="modal",
+                data_target="#purchase_modal",
+                data_dismiss="modal",
+            )

--- a/saas_app/templates/internal_ops/view_all_requests.html
+++ b/saas_app/templates/internal_ops/view_all_requests.html
@@ -58,7 +58,7 @@
       <tbody>
         {% for saas_request in purchase_needed_requests %}
             <tr>
-            <td>{{ saas_request.name}} </td>
+            <td><a href="{{saas_request.pk}}">{{ saas_request.name}} </a></td>
             <td>{{ saas_request.description }}</td>
             <td>{{ saas_request.url }}</td>
             <td>{{ saas_request.cost }}</td>

--- a/saas_app/templates/internal_ops/view_request.html
+++ b/saas_app/templates/internal_ops/view_request.html
@@ -40,8 +40,7 @@
     </div>
   </div>
 </div>
-
-
+{% get_current_language as CURRENT_LANGUAGE %}
 <div class="modal fade" id="purchase_modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
@@ -56,7 +55,7 @@
          {% csrf_token %}
           <div class="form-group">
             <label for="recipient-name" class="col-form-label"{% trans "Purchase Date:" %}</label>
-            <input type="date" class="form-control" name="purchase-date" id="purchase-date">
+            <input type="date" class="form-control" name="purchase-date" id="purchase-date" lang="{{CURRENT_LANGUAGE}}">
           </div>
           <div class="form-group">
             <label for="recipient-name" class="col-form-label">{% trans "Purchase Amount:" %}</label>


### PR DESCRIPTION
# Summary | Résumé

Hide the Purchase button until the request is approved by an S32 approver. After it is approved, then show the button. Closes #60 