### PR TITLE
Fixing up LB subnet type to be of type list of strings

### DIFF
--- a/terragrunt/aws/load_balancer/inputs.tf
+++ b/terragrunt/aws/load_balancer/inputs.tf
@@ -15,5 +15,5 @@ variable "vpc_cidr_block" {
 
 variable "vpc_public_subnet_ids" {
   description = "Public subnet ids of the VPC"
-  type        = string
+  type        = list(string)
 }

--- a/terragrunt/aws/load_balancer/load_balancer.tf
+++ b/terragrunt/aws/load_balancer/load_balancer.tf
@@ -11,7 +11,7 @@ resource "aws_lb" "saas_procurement" {
     aws_security_group.saas_procurement_load_balancer.id
   ]
 
-  subnets = [var.vpc_public_subnet_ids]
+  subnets = ["var.vpc_public_subnet_ids"]
 
   tags = {
     "CostCentre" = var.billing_code

--- a/terragrunt/aws/load_balancer/load_balancer.tf
+++ b/terragrunt/aws/load_balancer/load_balancer.tf
@@ -11,7 +11,7 @@ resource "aws_lb" "saas_procurement" {
     aws_security_group.saas_procurement_load_balancer.id
   ]
 
-  subnets = ["var.vpc_public_subnet_ids"]
+  subnets = var.vpc_public_subnet_ids
 
   tags = {
     "CostCentre" = var.billing_code


### PR DESCRIPTION
# Summary | Résumé

Originally in my terraform Load balancer code, I had the vpc_public_subnet_ids as a string but it was supposed to be a list of strings. 

Thanks @patheard for the correction!