### PR TITLE
Modifying search bar direction, removing menu items and adding full url to the email 

### DIFF
--- a/saas_app/common/util/utils.py
+++ b/saas_app/common/util/utils.py
@@ -1,5 +1,4 @@
 from notifications_python_client.notifications import NotificationsAPIClient
-from django.contrib.sites.models import Site
 from django.utils.translation import gettext as _
 import os
 
@@ -37,5 +36,4 @@ def send_email(email_address, template_id, details):
 
 # Get the current site domain
 def get_current_site(request):
-    current_site = Site.objects.get_current()
-    return current_site.domain
+    return request.build_absolute_uri("/")

--- a/saas_app/templates/base.html
+++ b/saas_app/templates/base.html
@@ -71,41 +71,34 @@
          </div> 
          {% block page_content %}
            {% if user.is_authenticated %}
-             <nav class="navbar navbar-expand-lg navbar-light bg-light">
-             <div class="container-fluid">
-             <a class="navbar-brand" href="{% url 'home' %}">{% trans "Home" %}</a>
-             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-              <span class="navbar-toggler-icon"></span>
-             </button>
-             <div class="collapse navbar-collapse" id="navbarSupportedContent">
+                <nav class="navbar navbar-expand-lg navbar-light bg-light">
+                  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                    <span class="navbar-toggler-icon"></span>
+                  </button>
+                <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav mr-auto">
-                  <li class="nav-item">
-                    <a class="nav-link" href="{% url 'socialaccount_connections' %}">{% trans "Google Accounts" %} <span class="sr-only">(current)</span></a>
-                  </li>
-                  {% if testing_feature_flag %}
-                    <li class="nav-item dropdown">
-                    <a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-expanded="false">
-                      {% trans "Switch Roles" %} 
-                    </a>
-                    <ul class="dropdown-menu">
-                      <li><a class="dropdown-item" href="{% url 'switch_role' %}?role=Requestor">{% trans "Requestor" %}</a></li>
-                      <li><a class="dropdown-item" href="{% url 'switch_role' %}?role=Manager">{% trans "Manager" %}</a></li>
-                      <li><a class="dropdown-item" href="{% url 'switch_role' %}?role=InternalOps">{% trans "Internal Ops" %}</a></li>
-                      <li><a class="dropdown-item" href="{% url 'switch_role' %}?role=S32Approver">{% trans "S32 Approver" %}</a></li>
-                    </ul>
-                  </li>
-                  {% endif %}
-                <li class="nav-item">
-                  <a class="nav-link" href="{% url 'account_logout' %}">{% trans "Sign Out" %}</a>
+                <li class="nav-item active">
+                  <a class="nav-link" href="{% url 'home' %}">{% trans "Home" %}<span class="sr-only">(current)</span></a>
                 </li>
-              <form name="search" class="form-inline my-2 my-lg-0" action="{% url 'search' %}">
-                <input name="search" class="form-control mr-sm-2" type="search" placeholder={% trans "Search" %} aria-label="Search">
-                  <button class="btn btn-outline-secondary my-2 my-sm-0" type="submit">{% trans "Search" %}</button>
-              </form>
-            </div>
-            </div>
-           </nav>
-           <br>
+                <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                {% trans "Switch Roles" %} 
+                </a>
+                <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+                  <a class="dropdown-item" href="{% url 'switch_role' %}?role=Requestor">{% trans "Requestor" %}</a>
+                  <a class="dropdown-item" href="{% url 'switch_role' %}?role=Manager">{% trans "Manager" %}</a>
+                  <a class="dropdown-item" href="{% url 'switch_role' %}?role=InternalOps">{% trans "Internal Ops" %}</a>
+                  <a class="dropdown-item" href="{% url 'switch_role' %}?role=S32Approver">{% trans "S32 Approver" %}</a>
+                </div>
+              </li>
+            </ul>
+            <form name="search" class="form-inline my-2 my-lg-0" action="{% url 'search' %}">
+              <input name="search" class="form-control mr-sm-2" type="search" placeholder={% trans "Search" %}  aria-label="Search">
+              <button class="btn btn-outline-secondary my-2 my-sm-0" type="submit">{% trans "Search" %}</button>
+            </form>
+          </div>
+          </nav>
+          <br>
           {% endif %}
           {% endblock %}
          {% if messages %}


### PR DESCRIPTION
# Summary | Résumé

Minor fixes which include

- Right aligning the search menu 
- Removing the google accounts menu option since it was more confusing than anything else
- Adding the full url to the emails sent out so that the user can click on them. 
<img width="1375" alt="Screenshot 2023-05-05 at 5 56 34 PM" src="https://user-images.githubusercontent.com/85905333/236589698-cae60182-58c1-43c1-b317-5c69fce3997e.png">
<img width="1073" alt="Screenshot 2023-05-05 at 5 56 58 PM" src="https://user-images.githubusercontent.com/85905333/236589710-dbf49054-d818-42e9-8767-2420c00e5937.png">
