### PR TITLE
Pin the configure-aws-credentials action to newer version

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
       - name: Configure AWS credentials using OIDC
-        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # tag=v1.7.0
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
         with:
           role-to-assume: arn:aws:iam::${{env.AWS_ACCOUNT}}:role/gh_plan_role
           role-session-name: ECRPush


### PR DESCRIPTION
# Summary | Résumé

Pinning the Aws credentials github action to a newer version since the previous version was quite outdated. 