### PR TITLE
Enabling output to see why the ECS restart is failing

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -54,7 +54,7 @@ jobs:
           
       - name: Restart ECS
         run: |
-          aws ecs update-service --cluster saas-procurement-cluster --service saas_procurement-service --force-new-deployment > /dev/null 2>&1
+          aws ecs update-service --cluster saas-procurement-cluster --service saas_procurement-service --force-new-deployment
 
       - name: Docker generate SBOM
         uses: cds-snc/security-tools/.github/actions/generate-sbom@cfec0943e40dbb78cee115bbbe89dc17f07b7a0f # v2.1.3    


### PR DESCRIPTION
# Summary | Résumé

Enabling output of the ecs restart aws cli command to see why the action is failing. 