### PR TITLE
Changing execution role of github action to be able to restart ECS

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Configure AWS credentials using OIDC
         uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
         with:
-          role-to-assume: arn:aws:iam::${{env.AWS_ACCOUNT}}:role/gh_plan_role
+          role-to-assume: arn:aws:iam::${{env.AWS_ACCOUNT}}:role/gh_admin_role
           role-session-name: ECRPush
           aws-region: ${{ env.AWS_REGION }}
 


### PR DESCRIPTION
# Summary | Résumé

Changing the role of the github action in order for the ECS task to be able to restart. 