### PR TITLE
Setting debug flag to true only in dev

### DIFF
--- a/saas_app/saas_app/settings.py
+++ b/saas_app/saas_app/settings.py
@@ -31,7 +31,7 @@ SECRET_KEY = (
     or "a$b+cdefgh=!i$jklmno!$(@p!qrstuvw^xyz123@4@5-67%89"
 )
 
-# DEBUG should be set to False in production 
+# DEBUG should be set to False in production
 if os.environ.get("ENVIRONMENT") == "dev":
     DEBUG = True
 else:

--- a/saas_app/saas_app/settings.py
+++ b/saas_app/saas_app/settings.py
@@ -31,8 +31,11 @@ SECRET_KEY = (
     or "a$b+cdefgh=!i$jklmno!$(@p!qrstuvw^xyz123@4@5-67%89"
 )
 
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+# DEBUG should be set to False in production 
+if os.environ.get("ENVIRONMENT") == "dev":
+    DEBUG = True
+else:
+    DEBUG = False
 
 ALLOWED_HOSTS = ["*"]
 


### PR DESCRIPTION
# Summary | Résumé

Turning off DEBUG in staging since testing is no longer needed. Now DEBUG flag is turned on only in development. 