### PR TITLE
Configure project to use WhiteNoise to be able to server its own static files

### DIFF
--- a/saas_app/requirements.txt
+++ b/saas_app/requirements.txt
@@ -13,3 +13,4 @@ django-crispy-forms==2.0
 crispy-bootstrap4==2022.1
 notifications-python-client==8.0.1
 pytz==2022.7.1
+whitenoise==6.4.0

--- a/saas_app/saas_app/settings.py
+++ b/saas_app/saas_app/settings.py
@@ -32,11 +32,10 @@ SECRET_KEY = (
 )
 
 # DEBUG should be set to False in production
-# if os.environ.get("ENVIRONMENT") == "dev":
-#     DEBUG = True
-# else:
-#     DEBUG = False
-DEBUG = True
+if os.environ.get("ENVIRONMENT") == "dev":
+    DEBUG = True
+else:
+    DEBUG = False
 
 ALLOWED_HOSTS = ["*"]
 
@@ -75,6 +74,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "saas_app.middleware.HealthCheckMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
 ]
 
 ROOT_URLCONF = "saas_app.urls"

--- a/saas_app/saas_app/wsgi.py
+++ b/saas_app/saas_app/wsgi.py
@@ -10,7 +10,9 @@ https://docs.djangoproject.com/en/4.1/howto/deployment/wsgi/
 import os
 
 from django.core.wsgi import get_wsgi_application
+from whitenoise import WhiteNoise
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "saas_app.settings")
 
 application = get_wsgi_application()
+application = WhiteNoise(application)


### PR DESCRIPTION
# Summary | Résumé

Configuring project with whitenoise so that our app will be able to serve its own static files when Debug mode is false, making it a self-contained unit without relying on nginx, apache or S3. This is an issue only when Debug=False as it should be in staging and production to not display extra information. Also configured the settings file to set Debug to True in test and False in staging or production. 