### PR TITLE
Adding log subscription filter to sentinel forwarder

### DIFF
--- a/terragrunt/aws/ecs/ecs.tf
+++ b/terragrunt/aws/ecs/ecs.tf
@@ -97,3 +97,11 @@ module "sentinel_forwarder" {
 
   cloudwatch_log_arns = [aws_cloudwatch_log_group.saas_procurement_group.arn]
 }
+
+resource "aws_cloudwatch_log_subscription_filter" "sentinel_forwarder" {
+  name            = "All ECS logs"
+  log_group_name  = aws_cloudwatch_log_group.saas_procurement_group.name
+  filter_pattern  = "[w1=\"*\"]"
+  destination_arn = module.sentinel_forwarder.lambda_arn
+  distribution    = "Random"
+}


### PR DESCRIPTION
# Summary | Résumé

Adding a subscription filter to send all logs to Sentinel. This invokes the lambda function when a matching pattern is detected (in this case, all logs are matched). 