### PR TITLE
Fixing up the path of the staticfiles in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,7 @@ db.sqlite3
 .env
 venv
 /pgdata
-/staticfiles/*
-!/staticfiles/.gitkeep
+saas_app/staticfiles/*
 __pycache__
 *.tfstate*
 secrets*.tfvars


### PR DESCRIPTION
# Summary | Résumé

Fixed up the path of .gitignore to ignore staticfiles in the saas_app directory since it was configured incorrectly. 