### PR TITLE
Internal Ops changes as requested

### DIFF
--- a/saas_app/approve/forms.py
+++ b/saas_app/approve/forms.py
@@ -30,6 +30,7 @@ class ViewRequestForm(ModelForm):
             "submitted_by",
         ]
         labels = {
+            "name": _("Name of Saas"),
             "currency": _("Currency"),
             "frequency": _("Frequency"),
             "units": _("Units"),
@@ -125,6 +126,7 @@ class ViewManagerOldRequestForm(ModelForm):
             "manager_denied",
         ]
         labels = {
+            "name": _("Name of Saas"),
             "status": _("Current status"),
             "currency": _("Currency"),
             "frequency": _("Frequency"),
@@ -225,6 +227,7 @@ class ViewS32ApproverOldRequestForm(ModelForm):
             "s_32_approved",
         ]
         labels = {
+            "name": _("Name of Saas"),
             "status": _("Current status"),
             "currency": _("Currency"),
             "frequency": _("Frequency"),

--- a/saas_app/approve/forms.py
+++ b/saas_app/approve/forms.py
@@ -104,7 +104,9 @@ class ViewRequestForm(ModelForm):
         )
         # unhide the date requested and information requested if there is data associated with those fields.
         if self.instance.date_info_requested is not None:
-            self.helper["date_info_requested"].update_attributes(type="text", readonly=True)
+            self.helper["date_info_requested"].update_attributes(
+                type="text", readonly=True
+            )
         if self.instance.info_requested is not None:
             self.helper["info_requested"].update_attributes(type="text", readonly=True)
 
@@ -213,7 +215,9 @@ class ViewManagerOldRequestForm(ModelForm):
         )
         # unhide the date requested and information requested if there is data associated with those fields.
         if self.instance.date_info_requested is not None:
-            self.helper["date_info_requested"].update_attributes(type="text", readonly=True)
+            self.helper["date_info_requested"].update_attributes(
+                type="text", readonly=True
+            )
         if self.instance.info_requested is not None:
             self.helper["info_requested"].update_attributes(type="text", readonly=True)
 
@@ -323,6 +327,8 @@ class ViewS32ApproverOldRequestForm(ModelForm):
         )
         # unhide the date requested and information requested if there is data associated with those fields.
         if self.instance.date_info_requested is not None:
-            self.helper["date_info_requested"].update_attributes(type="text", readonly=True)
+            self.helper["date_info_requested"].update_attributes(
+                type="text", readonly=True
+            )
         if self.instance.info_requested is not None:
             self.helper["info_requested"].update_attributes(type="text", readonly=True)

--- a/saas_app/approve/forms.py
+++ b/saas_app/approve/forms.py
@@ -26,6 +26,8 @@ class ViewRequestForm(ModelForm):
             "backup_administrator",
             "manager",
             "fund_center",
+            "date_info_requested",
+            "info_requested",
             "comments",
             "submitted_by",
         ]
@@ -37,6 +39,8 @@ class ViewRequestForm(ModelForm):
             "duration": _("Duration"),
             "fund_center": _("Fund Center"),
             "comments": _("Comments"),
+            "date_info_requested": _("Date Info Requested"),
+            "info_requested": _("Info Requested"),
         }
 
     def __init__(self, *args, **kwargs):
@@ -77,6 +81,8 @@ class ViewRequestForm(ModelForm):
                 style="height: auto; color:black; background-color:#e9ecef; opacity:1;font-weight: inherit;font-color: inherit;",
             ),
             Field("comments", disabled=True, rows="5"),
+            Field("info_requested", type="hidden"),
+            Field("date_info_requested", type="hidden"),
             Field(
                 "submitted_by",
                 disabled=True,
@@ -96,6 +102,11 @@ class ViewRequestForm(ModelForm):
                 onclick="history.back()",
             ),
         )
+        # unhide the date requested and information requested if there is data associated with those fields.
+        if self.instance.date_info_requested is not None:
+            self.helper["date_info_requested"].update_attributes(type="text", readonly=True)
+        if self.instance.info_requested is not None:
+            self.helper["info_requested"].update_attributes(type="text", readonly=True)
 
 
 class ViewManagerOldRequestForm(ModelForm):
@@ -124,6 +135,8 @@ class ViewManagerOldRequestForm(ModelForm):
             "date_manager_reviewed",
             "manager_approved",
             "manager_denied",
+            "info_requested",
+            "date_info_requested",
         ]
         labels = {
             "name": _("Name of Saas"),
@@ -137,6 +150,8 @@ class ViewManagerOldRequestForm(ModelForm):
             "manager_approved": _("Manager approved the request"),
             "manager_denied": _("Manager denied the request"),
             "comments": _("Comments"),
+            "date_info_requested": _("Date Info Requested"),
+            "info_requested": _("Info Requested"),
         }
 
     def __init__(self, *args, **kwargs):
@@ -186,6 +201,8 @@ class ViewManagerOldRequestForm(ModelForm):
             Field("date_manager_reviewed", disabled=True),
             Field("manager_approved", disabled=True),
             Field("manager_denied", disabled=True),
+            Field("info_requested", type="hidden"),
+            Field("date_info_requested", type="hidden"),
             Button(
                 "cancel",
                 _("Cancel"),
@@ -194,6 +211,11 @@ class ViewManagerOldRequestForm(ModelForm):
                 onclick="history.back()",
             ),
         )
+        # unhide the date requested and information requested if there is data associated with those fields.
+        if self.instance.date_info_requested is not None:
+            self.helper["date_info_requested"].update_attributes(type="text", readonly=True)
+        if self.instance.info_requested is not None:
+            self.helper["info_requested"].update_attributes(type="text", readonly=True)
 
 
 class ViewS32ApproverOldRequestForm(ModelForm):
@@ -222,6 +244,8 @@ class ViewS32ApproverOldRequestForm(ModelForm):
             "date_manager_reviewed",
             "manager_approved",
             "manager_denied",
+            "info_requested",
+            "date_info_requested",
             "date_sent_to_s_32_approver",
             "s_32_review_date",
             "s_32_approved",
@@ -241,6 +265,8 @@ class ViewS32ApproverOldRequestForm(ModelForm):
             "s_32_review_date": _("Date S32 approver reviewed the request"),
             "s_32_approved": _("S32 approver approved the request"),
             "comments": _("Comments"),
+            "date_info_requested": _("Date Info Requested"),
+            "info_requested": _("Info Requested"),
         }
 
     def __init__(self, *args, **kwargs):
@@ -282,6 +308,8 @@ class ViewS32ApproverOldRequestForm(ModelForm):
             Field("date_manager_reviewed", disabled=True),
             Field("manager_approved", disabled=True),
             Field("manager_denied", disabled=True),
+            Field("info_requested", type="hidden"),
+            Field("date_info_requested", type="hidden"),
             Field("date_sent_to_s_32_approver", disabled=True),
             Field("s_32_review_date", disabled=True),
             Field("s_32_approved", disabled=True),
@@ -293,3 +321,8 @@ class ViewS32ApproverOldRequestForm(ModelForm):
                 onclick="history.back()",
             ),
         )
+        # unhide the date requested and information requested if there is data associated with those fields.
+        if self.instance.date_info_requested is not None:
+            self.helper["date_info_requested"].update_attributes(type="text", readonly=True)
+        if self.instance.info_requested is not None:
+            self.helper["info_requested"].update_attributes(type="text", readonly=True)

--- a/saas_app/internal_ops/forms.py
+++ b/saas_app/internal_ops/forms.py
@@ -1,5 +1,5 @@
 from crispy_forms.helper import FormHelper
-from crispy_forms.layout import Submit, Layout, Button, Field 
+from crispy_forms.layout import Submit, Layout, Button, Field
 from django.forms import ModelForm
 from django.utils.translation import get_language, gettext_lazy as _
 from submit_request.models import SaasRequest
@@ -108,7 +108,7 @@ class ViewS32RequestForm(ModelForm):
             Field("date_info_requested", type="hidden"),
             Field("info_requested", type="hidden"),
             Field("fund_center"),
-            Field("approved_by"), 
+            Field("approved_by"),
             Submit(
                 "send_for_s32_approval",
                 _("Send for S32 Approval"),
@@ -159,9 +159,12 @@ class ViewS32RequestForm(ModelForm):
             )
         # unhide the date requested and information requested if there is data associated with those fields.
         if self.instance.date_info_requested is not None:
-            self.helper["date_info_requested"].update_attributes(type="text", readonly=True)
+            self.helper["date_info_requested"].update_attributes(
+                type="text", readonly=True
+            )
         if self.instance.info_requested is not None:
             self.helper["info_requested"].update_attributes(type="text", readonly=True)
+
 
 class ViewPurchaseRequiredForm(ModelForm):
     # Form is generated from the database fields.
@@ -258,13 +261,19 @@ class ViewPurchaseRequiredForm(ModelForm):
                 "submitted_by",
                 readonly=True,
                 style="color:black; height:auto; background-color:#e9ecef; opacity:1; font-weight: inherit; font-color: inherit;",
-            ), 
+            ),
             Field("date_info_requested", type="hidden"),
             Field("info_requested", type="hidden"),
-            Field("fund_center", readonly=True,
-                style="color:black; height:auto; background-color:#e9ecef; opacity:1; font-weight: inherit; font-color: inherit;"),
-            Field("approved_by", readonly=True,
-                style="color:black; height:auto; background-color:#e9ecef; opacity:1; font-weight: inherit; font-color: inherit;"),
+            Field(
+                "fund_center",
+                readonly=True,
+                style="color:black; height:auto; background-color:#e9ecef; opacity:1; font-weight: inherit; font-color: inherit;",
+            ),
+            Field(
+                "approved_by",
+                readonly=True,
+                style="color:black; height:auto; background-color:#e9ecef; opacity:1; font-weight: inherit; font-color: inherit;",
+            ),
             Button(
                 "request_info",
                 _("Request Additional Information"),
@@ -293,12 +302,14 @@ class ViewPurchaseRequiredForm(ModelForm):
                 + "/internal_ops/view'",
             ),
         )
-          # unhide the date requested and information requested if there is data associated with those fields.
+        # unhide the date requested and information requested if there is data associated with those fields.
         if self.instance.date_info_requested is not None:
-            self.helper["date_info_requested"].update_attributes(type="text", readonly=True)
+            self.helper["date_info_requested"].update_attributes(
+                type="text", readonly=True
+            )
         if self.instance.info_requested is not None:
             self.helper["info_requested"].update_attributes(type="text", readonly=True)
-            
+
 
 class ViewOldPurchasedRequestsForm(ModelForm):
     # Form is generated from the database fields.
@@ -437,9 +448,11 @@ class ViewOldPurchasedRequestsForm(ModelForm):
                 + "/internal_ops/view'",
             ),
         )
-          # unhide the date requested and information requested if there is data associated with those fields.
+        # unhide the date requested and information requested if there is data associated with those fields.
         if self.instance.date_info_requested is not None:
-            self.helper["date_info_requested"].update_attributes(type="text", readonly=True)
+            self.helper["date_info_requested"].update_attributes(
+                type="text", readonly=True
+            )
         if self.instance.info_requested is not None:
             self.helper["info_requested"].update_attributes(type="text", readonly=True)
 
@@ -549,8 +562,10 @@ class ViewOldS32ApprovedRequestsForm(ModelForm):
                 onclick="history.back()",
             ),
         )
-          # unhide the date requested and information requested if there is data associated with those fields.
+        # unhide the date requested and information requested if there is data associated with those fields.
         if self.instance.date_info_requested is not None:
-            self.helper["date_info_requested"].update_attributes(type="text", readonly=True)
+            self.helper["date_info_requested"].update_attributes(
+                type="text", readonly=True
+            )
         if self.instance.info_requested is not None:
             self.helper["info_requested"].update_attributes(type="text", readonly=True)

--- a/saas_app/internal_ops/forms.py
+++ b/saas_app/internal_ops/forms.py
@@ -214,7 +214,7 @@ class ViewPurchaseRequiredForm(ModelForm):
             "date_manager_reviewed": _("Date Manager reviewed the request"),
             "manager_approved": _("Manager Approved"),
             "Manager_denied": _("Manager Denied"),
-            "submitted_by": _("Submitted By 123"),
+            "submitted_by": _("Submitted By"),
             "date_info_requested": _("Date Info Requested"),
             "info_requested": _("Info Requested"),
             "fund_center": _("Fund Center"),

--- a/saas_app/internal_ops/forms.py
+++ b/saas_app/internal_ops/forms.py
@@ -66,14 +66,22 @@ class ViewS32RequestForm(ModelForm):
         self.helper.form_id = "view_request_form"
         self.helper.form_class = "blueForms"
         self.fields["date_info_requested"].label = False
-        self.fields['info_requested'].label = False
+        self.fields["info_requested"].label = False
         self.helper.layout = Layout(
             Field("name", readonly=True),
             Field("url", readonly=True),
             Field("description", readonly=True),
             Field("cost", readonly=True),
-            Field("currency", readonly=True, style="color:black; height:auto; background-color:#e9ecef; opacity:1;font-weight: inherit;font-color: inherit;"),
-            Field("frequency", readonly=True, style="color:black; height:auto; background-color:#e9ecef; opacity:1;font-weight: inherit;font-color: inherit;"),
+            Field(
+                "currency",
+                readonly=True,
+                style="color:black; height:auto; background-color:#e9ecef; opacity:1;font-weight: inherit;font-color: inherit;",
+            ),
+            Field(
+                "frequency",
+                readonly=True,
+                style="color:black; height:auto; background-color:#e9ecef; opacity:1;font-weight: inherit;font-color: inherit;",
+            ),
             Field("units", readonly=True),
             Field("level_of_subscription", readonly=True),
             Field("duration", readonly=True),
@@ -147,12 +155,15 @@ class ViewS32RequestForm(ModelForm):
             )
         # unhide the date requested and information requested if there is data associated with those fields.
         if self.instance.date_info_requested:
-            self.helper.layout[17] = Field("date_info_requested", readonly=True, hidden=False)
-            self.fields["date_info_requested"].label = "Date Info Requested" 
+            self.helper.layout[17] = Field(
+                "date_info_requested", readonly=True, hidden=False
+            )
+            self.fields["date_info_requested"].label = "Date Info Requested"
         if self.instance.info_requested:
-            self.helper.layout[18] = Field("info_requested", readonly=True, hidden=False)
-            self.fields['info_requested'].label = "Info Requested" 
-
+            self.helper.layout[18] = Field(
+                "info_requested", readonly=True, hidden=False
+            )
+            self.fields["info_requested"].label = "Info Requested"
 
 
 class ViewPurchaseRequiredForm(ModelForm):
@@ -212,14 +223,22 @@ class ViewPurchaseRequiredForm(ModelForm):
         self.helper.form_id = "view_request_form"
         self.helper.form_class = "blueForms"
         self.fields["date_info_requested"].label = False
-        self.fields['info_requested'].label = False
+        self.fields["info_requested"].label = False
         self.helper.layout = Layout(
             Field("name", readonly=True),
             Field("url", readonly=True),
             Field("description", readonly=True),
             Field("cost", readonly=True),
-            Field("currency", readonly=True, style="color:black; height:auto; background-color:#e9ecef; opacity:1;font-weight: inherit;font-color: inherit;"),
-            Field("frequency", readonly=True, style="color:black; height:auto; background-color:#e9ecef; opacity:1;font-weight: inherit;font-color: inherit;"),
+            Field(
+                "currency",
+                readonly=True,
+                style="color:black; height:auto; background-color:#e9ecef; opacity:1;font-weight: inherit;font-color: inherit;",
+            ),
+            Field(
+                "frequency",
+                readonly=True,
+                style="color:black; height:auto; background-color:#e9ecef; opacity:1;font-weight: inherit;font-color: inherit;",
+            ),
             Field("units", readonly=True),
             Field("level_of_subscription", readonly=True),
             Field("duration", readonly=True),
@@ -272,11 +291,15 @@ class ViewPurchaseRequiredForm(ModelForm):
             ),
         )
         if self.instance.date_info_requested:
-            self.helper.layout[17] = Field("date_info_requested", readonly=True, hidden=False)
+            self.helper.layout[17] = Field(
+                "date_info_requested", readonly=True, hidden=False
+            )
             self.fields["date_info_requested"].label = "Date Info Requested"
         if self.instance.info_requested:
-            self.helper.layout[18] = Field("info_requested", readonly=True, hidden=False)
-            self.fields['info_requested'].label = "Info Requested"
+            self.helper.layout[18] = Field(
+                "info_requested", readonly=True, hidden=False
+            )
+            self.fields["info_requested"].label = "Info Requested"
 
 
 class ViewOldPurchasedRequestsForm(ModelForm):
@@ -349,14 +372,22 @@ class ViewOldPurchasedRequestsForm(ModelForm):
         self.helper.form_id = "view_request_form"
         self.helper.form_class = "blueForms"
         self.fields["date_info_requested"].label = False
-        self.fields['info_requested'].label = False
+        self.fields["info_requested"].label = False
         self.helper.layout = Layout(
             Field("name", readonly=True),
             Field("url", readonly=True),
             Field("description", readonly=True),
             Field("cost", readonly=True),
-            Field("currency", readonly=True, style="color:black; height:auto; background-color:#e9ecef; opacity:1;font-weight: inherit;font-color: inherit;"),
-            Field("frequency", readonly=True, style="color:black; height:auto; background-color:#e9ecef; opacity:1;font-weight: inherit;font-color: inherit;"),
+            Field(
+                "currency",
+                readonly=True,
+                style="color:black; height:auto; background-color:#e9ecef; opacity:1;font-weight: inherit;font-color: inherit;",
+            ),
+            Field(
+                "frequency",
+                readonly=True,
+                style="color:black; height:auto; background-color:#e9ecef; opacity:1;font-weight: inherit;font-color: inherit;",
+            ),
             Field("units", readonly=True),
             Field("level_of_subscription", readonly=True),
             Field("duration", readonly=True),
@@ -409,11 +440,16 @@ class ViewOldPurchasedRequestsForm(ModelForm):
             ),
         )
         if self.instance.date_info_requested:
-            self.helper.layout[19] = Field("date_info_requested", readonly=True, hidden=False)
+            self.helper.layout[19] = Field(
+                "date_info_requested", readonly=True, hidden=False
+            )
             self.fields["date_info_requested"].label = "Date Info Requested"
         if self.instance.info_requested:
-            self.helper.layout[20] = Field("info_requested", readonly=True, hidden=False)
-            self.fields['info_requested'].label = "Info Requested"
+            self.helper.layout[20] = Field(
+                "info_requested", readonly=True, hidden=False
+            )
+            self.fields["info_requested"].label = "Info Requested"
+
 
 class ViewOldS32ApprovedRequestsForm(ModelForm):
     # Form is generated from the database fields.
@@ -471,14 +507,22 @@ class ViewOldS32ApprovedRequestsForm(ModelForm):
         self.helper.form_id = "view_request_form"
         self.helper.form_class = "blueForms"
         self.fields["date_info_requested"].label = False
-        self.fields['info_requested'].label = False
+        self.fields["info_requested"].label = False
         self.helper.layout = Layout(
             Field("name", readonly=True),
             Field("url", readonly=True),
             Field("description", readonly=True),
             Field("cost", readonly=True),
-            Field("currency", readonly=True, style="color:black; height:auto; background-color:#e9ecef; opacity:1;font-weight: inherit;font-color: inherit;"),
-            Field("frequency", readonly=True, style="color:black; height:auto; background-color:#e9ecef; opacity:1;font-weight: inherit;font-color: inherit;"),
+            Field(
+                "currency",
+                readonly=True,
+                style="color:black; height:auto; background-color:#e9ecef; opacity:1;font-weight: inherit;font-color: inherit;",
+            ),
+            Field(
+                "frequency",
+                readonly=True,
+                style="color:black; height:auto; background-color:#e9ecef; opacity:1;font-weight: inherit;font-color: inherit;",
+            ),
             Field("units", readonly=True),
             Field("level_of_subscription", readonly=True),
             Field("number_of_users", readonly=True),
@@ -500,7 +544,7 @@ class ViewOldS32ApprovedRequestsForm(ModelForm):
                 style="color:black; height:auto; background-color:#e9ecef; opacity:1; font-weight: inherit; font-color: inherit;",
             ),
             Field("date_info_requested", readonly=True, hidden=True),
-            Field("info_requested", readonly=True, hidden=True), 
+            Field("info_requested", readonly=True, hidden=True),
             Field("date_sent_to_s_32_approver", readonly=True),
             Field("fund_center", readonly=True, style="height:auto"),
             Field("approved_by", readonly=True, style="height:auto"),
@@ -513,8 +557,12 @@ class ViewOldS32ApprovedRequestsForm(ModelForm):
             ),
         )
         if self.instance.date_info_requested:
-            self.helper.layout[20] = Field("date_info_requested", readonly=True, hidden=False)
+            self.helper.layout[20] = Field(
+                "date_info_requested", readonly=True, hidden=False
+            )
             self.fields["date_info_requested"].label = "Date Info Requested"
         if self.instance.info_requested:
-            self.helper.layout[21] = Field("info_requested", readonly=True, hidden=False)
-            self.fields['info_requested'].label = "Info Requested"
+            self.helper.layout[21] = Field(
+                "info_requested", readonly=True, hidden=False
+            )
+            self.fields["info_requested"].label = "Info Requested"

--- a/saas_app/internal_ops/forms.py
+++ b/saas_app/internal_ops/forms.py
@@ -208,6 +208,7 @@ class ViewPurchaseRequiredForm(ModelForm):
             "account_administrator": _("Account Administrator"),
             "backup_administrator": _("Backup Administrator"),
             "manager": _("Manager"),
+            "comments": _("Comments"),
             "manager_approved": _("Manager Approved"),
             "Manager_denied": _("Manager Denied"),
             # "date_info_requested": _("Date Info Requested"),

--- a/saas_app/internal_ops/forms.py
+++ b/saas_app/internal_ops/forms.py
@@ -1,5 +1,5 @@
 from crispy_forms.helper import FormHelper
-from crispy_forms.layout import Submit, Layout, Button, Field
+from crispy_forms.layout import Submit, Layout, Button, Field 
 from django.forms import ModelForm
 from django.utils.translation import get_language, gettext_lazy as _
 from submit_request.models import SaasRequest
@@ -30,6 +30,8 @@ class ViewS32RequestForm(ModelForm):
             "manager",
             "comments",
             "date_manager_reviewed",
+            "manager_approved",
+            "manager_denied",
             "submitted_by",
             "date_info_requested",
             "info_requested",
@@ -56,6 +58,8 @@ class ViewS32RequestForm(ModelForm):
             "manager_approved": _("Manager Approved"),
             "manager_denied": _("Manager Denied"),
             "submitted_by": _("Submitted By"),
+            "date_info_requested": _("Date Info Requested"),
+            "info_requested": _("Info Requested"),
             "fund_center": _("Fund Center"),
             "approved_by": _("S32 Approver"),
         }
@@ -65,8 +69,6 @@ class ViewS32RequestForm(ModelForm):
         self.helper = FormHelper()
         self.helper.form_id = "view_request_form"
         self.helper.form_class = "blueForms"
-        self.fields["date_info_requested"].label = False
-        self.fields["info_requested"].label = False
         self.helper.layout = Layout(
             Field("name", readonly=True),
             Field("url", readonly=True),
@@ -96,15 +98,17 @@ class ViewS32RequestForm(ModelForm):
             ),
             Field("comments", readonly=True, rows="5"),
             Field("date_manager_reviewed", readonly=True),
+            Field("manager_approved", readonly=True),
+            Field("manager_denied", readonly=True),
             Field(
                 "submitted_by",
                 readonly=True,
                 style="color:black; height:auto; background-color:#e9ecef; opacity:1; font-weight: inherit; font-color: inherit;",
             ),
-            Field("date_info_requested", readonly=True, hidden=True),
-            Field("info_requested", readonly=True, hidden=True),
-            Field("fund_center", style="height:auto"),
-            Field("approved_by", style="height:auto"),
+            Field("date_info_requested", type="hidden"),
+            Field("info_requested", type="hidden"),
+            Field("fund_center"),
+            Field("approved_by"), 
             Submit(
                 "send_for_s32_approval",
                 _("Send for S32 Approval"),
@@ -154,17 +158,10 @@ class ViewS32RequestForm(ModelForm):
                 data_dismiss="modal",
             )
         # unhide the date requested and information requested if there is data associated with those fields.
-        if self.instance.date_info_requested:
-            self.helper.layout[17] = Field(
-                "date_info_requested", readonly=True, hidden=False
-            )
-            self.fields["date_info_requested"].label = "Date Info Requested"
-        if self.instance.info_requested:
-            self.helper.layout[18] = Field(
-                "info_requested", readonly=True, hidden=False
-            )
-            self.fields["info_requested"].label = "Info Requested"
-
+        if self.instance.date_info_requested is not None:
+            self.helper["date_info_requested"].update_attributes(type="text", readonly=True)
+        if self.instance.info_requested is not None:
+            self.helper["info_requested"].update_attributes(type="text", readonly=True)
 
 class ViewPurchaseRequiredForm(ModelForm):
     # Form is generated from the database fields.
@@ -187,6 +184,8 @@ class ViewPurchaseRequiredForm(ModelForm):
             "manager",
             "comments",
             "date_manager_reviewed",
+            "manager_approved",
+            "manager_denied",
             "submitted_by",
             "date_info_requested",
             "info_requested",
@@ -209,11 +208,12 @@ class ViewPurchaseRequiredForm(ModelForm):
             "backup_administrator": _("Backup Administrator"),
             "manager": _("Manager"),
             "comments": _("Comments"),
+            "date_manager_reviewed": _("Date Manager reviewed the request"),
             "manager_approved": _("Manager Approved"),
             "Manager_denied": _("Manager Denied"),
-            # "date_info_requested": _("Date Info Requested"),
-            # "info_requested": _("Info Requested"),
-            "submitted_by": _("Submitted By"),
+            "submitted_by": _("Submitted By 123"),
+            "date_info_requested": _("Date Info Requested"),
+            "info_requested": _("Info Requested"),
             "fund_center": _("Fund Center"),
             "approved_by": _("S32 Approver"),
         }
@@ -223,8 +223,6 @@ class ViewPurchaseRequiredForm(ModelForm):
         self.helper = FormHelper()
         self.helper.form_id = "view_request_form"
         self.helper.form_class = "blueForms"
-        # self.fields["date_info_requested"].label = False
-        # self.fields["info_requested"].label = False
         self.helper.layout = Layout(
             Field("name", readonly=True),
             Field("url", readonly=True),
@@ -254,15 +252,19 @@ class ViewPurchaseRequiredForm(ModelForm):
             ),
             Field("comments", readonly=True, rows="5"),
             Field("date_manager_reviewed", readonly=True),
+            Field("manager_approved", readonly=True),
+            Field("manager_denied", readonly=True),
             Field(
                 "submitted_by",
                 readonly=True,
                 style="color:black; height:auto; background-color:#e9ecef; opacity:1; font-weight: inherit; font-color: inherit;",
-            ),
-            Field("date_info_requested", readonly=True, hidden=True),
-            Field("info_requested", readonly=True, hidden=True),
-            Field("fund_center", style="height:auto"),
-            Field("approved_by", style="height:auto"),
+            ), 
+            Field("date_info_requested", type="hidden"),
+            Field("info_requested", type="hidden"),
+            Field("fund_center", readonly=True,
+                style="color:black; height:auto; background-color:#e9ecef; opacity:1; font-weight: inherit; font-color: inherit;"),
+            Field("approved_by", readonly=True,
+                style="color:black; height:auto; background-color:#e9ecef; opacity:1; font-weight: inherit; font-color: inherit;"),
             Button(
                 "request_info",
                 _("Request Additional Information"),
@@ -291,17 +293,12 @@ class ViewPurchaseRequiredForm(ModelForm):
                 + "/internal_ops/view'",
             ),
         )
-        if self.instance.date_info_requested:
-            self.helper.layout[17] = Field(
-                "date_info_requested", readonly=True, hidden=False
-            )
-            self.fields["date_info_requested"].label = "Date Info Requested"
-        if self.instance.info_requested:
-            self.helper.layout[18] = Field(
-                "info_requested", readonly=True, hidden=False
-            )
-            self.fields["info_requested"].label = "Info Requested"
-
+          # unhide the date requested and information requested if there is data associated with those fields.
+        if self.instance.date_info_requested is not None:
+            self.helper["date_info_requested"].update_attributes(type="text", readonly=True)
+        if self.instance.info_requested is not None:
+            self.helper["info_requested"].update_attributes(type="text", readonly=True)
+            
 
 class ViewOldPurchasedRequestsForm(ModelForm):
     # Form is generated from the database fields.
@@ -355,6 +352,8 @@ class ViewOldPurchasedRequestsForm(ModelForm):
             "date_manager_reviewed": _("Date Manager reviewed the request"),
             "manager_approved": _("Manager Approved"),
             "manager_denied": _("Manager Denied"),
+            "date_info_requested": _("Date Info Requested"),
+            "info_requested": _("Info Requested"),
             "date_sent_to_s_32_approver": _("Date Sent to S32 Approver"),
             "fund_center": _("Fund Center"),
             "approved_by": _("S32 Approver"),
@@ -372,8 +371,6 @@ class ViewOldPurchasedRequestsForm(ModelForm):
         self.helper = FormHelper()
         self.helper.form_id = "view_request_form"
         self.helper.form_class = "blueForms"
-        # self.fields["date_info_requested"].label = False
-        # self.fields["info_requested"].label = False
         self.helper.layout = Layout(
             Field("name", readonly=True),
             Field("url", readonly=True),
@@ -410,8 +407,8 @@ class ViewOldPurchasedRequestsForm(ModelForm):
                 readonly=True,
                 style="color:black; height:auto; background-color:#e9ecef; opacity:1; font-weight: inherit; font-color: inherit;",
             ),
-            Field("date_info_requested", readonly=True, hidden=True),
-            Field("info_requested", readonly=True, hidden=True),
+            Field("date_info_requested", type="hidden"),
+            Field("info_requested", type="hidden"),
             Field("date_sent_to_s_32_approver", readonly=True),
             Field("s_32_review_date", readonly=True),
             Field("s_32_approved", readonly=True),
@@ -440,16 +437,11 @@ class ViewOldPurchasedRequestsForm(ModelForm):
                 + "/internal_ops/view'",
             ),
         )
-        if self.instance.date_info_requested:
-            self.helper.layout[19] = Field(
-                "date_info_requested", readonly=True, hidden=False
-            )
-            self.fields["date_info_requested"].label = "Date Info Requested"
-        if self.instance.info_requested:
-            self.helper.layout[20] = Field(
-                "info_requested", readonly=True, hidden=False
-            )
-            self.fields["info_requested"].label = "Info Requested"
+          # unhide the date requested and information requested if there is data associated with those fields.
+        if self.instance.date_info_requested is not None:
+            self.helper["date_info_requested"].update_attributes(type="text", readonly=True)
+        if self.instance.info_requested is not None:
+            self.helper["info_requested"].update_attributes(type="text", readonly=True)
 
 
 class ViewOldS32ApprovedRequestsForm(ModelForm):
@@ -495,6 +487,8 @@ class ViewOldS32ApprovedRequestsForm(ModelForm):
             "date_manager_reviewed": _("Date Manager reviewed the request"),
             "manager_approved": _("Manager Approved"),
             "manager_denied": _("Manager Denied"),
+            "date_info_requested": _("Date Info Requested"),
+            "info_requested": _("Info Requested"),
             "date_sent_to_s_32_approver": _("Date Sent to S32 Approver"),
             "fund_center": _("Fund Center"),
             "approved_by": _("S32 Approver"),
@@ -507,8 +501,6 @@ class ViewOldS32ApprovedRequestsForm(ModelForm):
         self.helper = FormHelper()
         self.helper.form_id = "view_request_form"
         self.helper.form_class = "blueForms"
-        # self.fields["date_info_requested"].label = False
-        # self.fields["info_requested"].label = False
         self.helper.layout = Layout(
             Field("name", readonly=True),
             Field("url", readonly=True),
@@ -544,8 +536,8 @@ class ViewOldS32ApprovedRequestsForm(ModelForm):
                 readonly=True,
                 style="color:black; height:auto; background-color:#e9ecef; opacity:1; font-weight: inherit; font-color: inherit;",
             ),
-            Field("date_info_requested", readonly=True, hidden=True),
-            Field("info_requested", readonly=True, hidden=True),
+            Field("date_info_requested", type="hidden"),
+            Field("info_requested", type="hidden"),
             Field("date_sent_to_s_32_approver", readonly=True),
             Field("fund_center", readonly=True, style="height:auto"),
             Field("approved_by", readonly=True, style="height:auto"),
@@ -557,13 +549,8 @@ class ViewOldS32ApprovedRequestsForm(ModelForm):
                 onclick="history.back()",
             ),
         )
-        if self.instance.date_info_requested:
-            self.helper.layout[20] = Field(
-                "date_info_requested", readonly=True, hidden=False
-            )
-            self.fields["date_info_requested"].label = "Date Info Requested"
-        if self.instance.info_requested:
-            self.helper.layout[21] = Field(
-                "info_requested", readonly=True, hidden=False
-            )
-            self.fields["info_requested"].label = "Info Requested"
+          # unhide the date requested and information requested if there is data associated with those fields.
+        if self.instance.date_info_requested is not None:
+            self.helper["date_info_requested"].update_attributes(type="text", readonly=True)
+        if self.instance.info_requested is not None:
+            self.helper["info_requested"].update_attributes(type="text", readonly=True)

--- a/saas_app/internal_ops/forms.py
+++ b/saas_app/internal_ops/forms.py
@@ -37,7 +37,7 @@ class ViewS32RequestForm(ModelForm):
             "approved_by",
         ]
         labels = {
-            "name": _("Name"),
+            "name": _("Name of Saas"),
             "url": _("URL"),
             "description": _("Description"),
             "cost": _("Cost"),
@@ -194,7 +194,7 @@ class ViewPurchaseRequiredForm(ModelForm):
             "approved_by",
         ]
         labels = {
-            "name": _("Name"),
+            "name": _("Name of Saas"),
             "url": _("URL"),
             "description": _("Description"),
             "cost": _("Cost"),
@@ -210,8 +210,8 @@ class ViewPurchaseRequiredForm(ModelForm):
             "manager": _("Manager"),
             "manager_approved": _("Manager Approved"),
             "Manager_denied": _("Manager Denied"),
-            "date_info_requested": _("Date Info Requested"),
-            "info_requested": _("Info Requested"),
+            # "date_info_requested": _("Date Info Requested"),
+            # "info_requested": _("Info Requested"),
             "submitted_by": _("Submitted By"),
             "fund_center": _("Fund Center"),
             "approved_by": _("S32 Approver"),
@@ -222,8 +222,8 @@ class ViewPurchaseRequiredForm(ModelForm):
         self.helper = FormHelper()
         self.helper.form_id = "view_request_form"
         self.helper.form_class = "blueForms"
-        self.fields["date_info_requested"].label = False
-        self.fields["info_requested"].label = False
+        # self.fields["date_info_requested"].label = False
+        # self.fields["info_requested"].label = False
         self.helper.layout = Layout(
             Field("name", readonly=True),
             Field("url", readonly=True),
@@ -340,7 +340,7 @@ class ViewOldPurchasedRequestsForm(ModelForm):
             "approved_by",
         ]
         labels = {
-            "name": _("Name"),
+            "name": _("Name of Saas"),
             "url": _("URL"),
             "description": _("Description"),
             "cost": _("Cost"),
@@ -371,8 +371,8 @@ class ViewOldPurchasedRequestsForm(ModelForm):
         self.helper = FormHelper()
         self.helper.form_id = "view_request_form"
         self.helper.form_class = "blueForms"
-        self.fields["date_info_requested"].label = False
-        self.fields["info_requested"].label = False
+        # self.fields["date_info_requested"].label = False
+        # self.fields["info_requested"].label = False
         self.helper.layout = Layout(
             Field("name", readonly=True),
             Field("url", readonly=True),
@@ -506,8 +506,8 @@ class ViewOldS32ApprovedRequestsForm(ModelForm):
         self.helper = FormHelper()
         self.helper.form_id = "view_request_form"
         self.helper.form_class = "blueForms"
-        self.fields["date_info_requested"].label = False
-        self.fields["info_requested"].label = False
+        # self.fields["date_info_requested"].label = False
+        # self.fields["info_requested"].label = False
         self.helper.layout = Layout(
             Field("name", readonly=True),
             Field("url", readonly=True),

--- a/saas_app/internal_ops/forms.py
+++ b/saas_app/internal_ops/forms.py
@@ -56,8 +56,6 @@ class ViewS32RequestForm(ModelForm):
             "manager_approved": _("Manager Approved"),
             "manager_denied": _("Manager Denied"),
             "submitted_by": _("Submitted By"),
-            "date_info_requested": _("Date Info Requested"),
-            "info_requested": _("Info Requested"),
             "fund_center": _("Fund Center"),
             "approved_by": _("S32 Approver"),
         }
@@ -67,13 +65,15 @@ class ViewS32RequestForm(ModelForm):
         self.helper = FormHelper()
         self.helper.form_id = "view_request_form"
         self.helper.form_class = "blueForms"
+        self.fields["date_info_requested"].label = False
+        self.fields['info_requested'].label = False
         self.helper.layout = Layout(
             Field("name", readonly=True),
             Field("url", readonly=True),
             Field("description", readonly=True),
             Field("cost", readonly=True),
-            Field("currency", readonly=True, style="height: auto;"),
-            Field("frequency", readonly=True, style="height: auto;"),
+            Field("currency", readonly=True, style="color:black; height:auto; background-color:#e9ecef; opacity:1;font-weight: inherit;font-color: inherit;"),
+            Field("frequency", readonly=True, style="color:black; height:auto; background-color:#e9ecef; opacity:1;font-weight: inherit;font-color: inherit;"),
             Field("units", readonly=True),
             Field("level_of_subscription", readonly=True),
             Field("duration", readonly=True),
@@ -93,14 +93,10 @@ class ViewS32RequestForm(ModelForm):
                 readonly=True,
                 style="color:black; height:auto; background-color:#e9ecef; opacity:1; font-weight: inherit; font-color: inherit;",
             ),
-            Field("date_info_requested", readonly=True),
-            Field("info_requested", readonly=True),
-            Field("fund_center"),
+            Field("date_info_requested", readonly=True, hidden=True),
+            Field("info_requested", readonly=True, hidden=True),
+            Field("fund_center", style="height:auto"),
             Field("approved_by", style="height:auto"),
-            Submit(
-                "save",
-                _("Update fund center and/or add s32 approver"),
-            ),
             Submit(
                 "send_for_s32_approval",
                 _("Send for S32 Approval"),
@@ -149,6 +145,14 @@ class ViewS32RequestForm(ModelForm):
                 data_target="#purchase_modal",
                 data_dismiss="modal",
             )
+        # unhide the date requested and information requested if there is data associated with those fields.
+        if self.instance.date_info_requested:
+            self.helper.layout[17] = Field("date_info_requested", readonly=True, hidden=False)
+            self.fields["date_info_requested"].label = "Date Info Requested" 
+        if self.instance.info_requested:
+            self.helper.layout[18] = Field("info_requested", readonly=True, hidden=False)
+            self.fields['info_requested'].label = "Info Requested" 
+
 
 
 class ViewPurchaseRequiredForm(ModelForm):
@@ -197,8 +201,6 @@ class ViewPurchaseRequiredForm(ModelForm):
             "Manager_denied": _("Manager Denied"),
             "date_info_requested": _("Date Info Requested"),
             "info_requested": _("Info Requested"),
-            "date_sent_to_s_32_approver": _("Date Sent to S32 Approver"),
-            "date_manager_reviewed": _("Date Manager reviewed the request"),
             "submitted_by": _("Submitted By"),
             "fund_center": _("Fund Center"),
             "approved_by": _("S32 Approver"),
@@ -209,13 +211,15 @@ class ViewPurchaseRequiredForm(ModelForm):
         self.helper = FormHelper()
         self.helper.form_id = "view_request_form"
         self.helper.form_class = "blueForms"
+        self.fields["date_info_requested"].label = False
+        self.fields['info_requested'].label = False
         self.helper.layout = Layout(
             Field("name", readonly=True),
             Field("url", readonly=True),
             Field("description", readonly=True),
             Field("cost", readonly=True),
-            Field("currency", readonly=True, style="height: auto;"),
-            Field("frequency", readonly=True, style="height: auto;"),
+            Field("currency", readonly=True, style="color:black; height:auto; background-color:#e9ecef; opacity:1;font-weight: inherit;font-color: inherit;"),
+            Field("frequency", readonly=True, style="color:black; height:auto; background-color:#e9ecef; opacity:1;font-weight: inherit;font-color: inherit;"),
             Field("units", readonly=True),
             Field("level_of_subscription", readonly=True),
             Field("duration", readonly=True),
@@ -235,9 +239,9 @@ class ViewPurchaseRequiredForm(ModelForm):
                 readonly=True,
                 style="color:black; height:auto; background-color:#e9ecef; opacity:1; font-weight: inherit; font-color: inherit;",
             ),
-            Field("date_info_requested", readonly=True),
-            Field("info_requested", readonly=True),
-            Field("fund_center"),
+            Field("date_info_requested", readonly=True, hidden=True),
+            Field("info_requested", readonly=True, hidden=True),
+            Field("fund_center", style="height:auto"),
             Field("approved_by", style="height:auto"),
             Button(
                 "request_info",
@@ -267,6 +271,12 @@ class ViewPurchaseRequiredForm(ModelForm):
                 + "/internal_ops/view'",
             ),
         )
+        if self.instance.date_info_requested:
+            self.helper.layout[17] = Field("date_info_requested", readonly=True, hidden=False)
+            self.fields["date_info_requested"].label = "Date Info Requested"
+        if self.instance.info_requested:
+            self.helper.layout[18] = Field("info_requested", readonly=True, hidden=False)
+            self.fields['info_requested'].label = "Info Requested"
 
 
 class ViewOldPurchasedRequestsForm(ModelForm):
@@ -321,8 +331,6 @@ class ViewOldPurchasedRequestsForm(ModelForm):
             "date_manager_reviewed": _("Date Manager reviewed the request"),
             "manager_approved": _("Manager Approved"),
             "manager_denied": _("Manager Denied"),
-            "date_info_requested": _("Date Info Requested"),
-            "info_requested": _("Info Requested"),
             "date_sent_to_s_32_approver": _("Date Sent to S32 Approver"),
             "fund_center": _("Fund Center"),
             "approved_by": _("S32 Approver"),
@@ -340,13 +348,15 @@ class ViewOldPurchasedRequestsForm(ModelForm):
         self.helper = FormHelper()
         self.helper.form_id = "view_request_form"
         self.helper.form_class = "blueForms"
+        self.fields["date_info_requested"].label = False
+        self.fields['info_requested'].label = False
         self.helper.layout = Layout(
             Field("name", readonly=True),
             Field("url", readonly=True),
             Field("description", readonly=True),
             Field("cost", readonly=True),
-            Field("currency", readonly=True, style="height: auto;"),
-            Field("frequency", readonly=True, style="height: auto;"),
+            Field("currency", readonly=True, style="color:black; height:auto; background-color:#e9ecef; opacity:1;font-weight: inherit;font-color: inherit;"),
+            Field("frequency", readonly=True, style="color:black; height:auto; background-color:#e9ecef; opacity:1;font-weight: inherit;font-color: inherit;"),
             Field("units", readonly=True),
             Field("level_of_subscription", readonly=True),
             Field("duration", readonly=True),
@@ -368,8 +378,8 @@ class ViewOldPurchasedRequestsForm(ModelForm):
                 readonly=True,
                 style="color:black; height:auto; background-color:#e9ecef; opacity:1; font-weight: inherit; font-color: inherit;",
             ),
-            Field("date_info_requested", readonly=True),
-            Field("info_requested", readonly=True),
+            Field("date_info_requested", readonly=True, hidden=True),
+            Field("info_requested", readonly=True, hidden=True),
             Field("date_sent_to_s_32_approver", readonly=True),
             Field("s_32_review_date", readonly=True),
             Field("s_32_approved", readonly=True),
@@ -398,7 +408,12 @@ class ViewOldPurchasedRequestsForm(ModelForm):
                 + "/internal_ops/view'",
             ),
         )
-
+        if self.instance.date_info_requested:
+            self.helper.layout[19] = Field("date_info_requested", readonly=True, hidden=False)
+            self.fields["date_info_requested"].label = "Date Info Requested"
+        if self.instance.info_requested:
+            self.helper.layout[20] = Field("info_requested", readonly=True, hidden=False)
+            self.fields['info_requested'].label = "Info Requested"
 
 class ViewOldS32ApprovedRequestsForm(ModelForm):
     # Form is generated from the database fields.
@@ -431,6 +446,7 @@ class ViewOldS32ApprovedRequestsForm(ModelForm):
             "approved_by",
         ]
         labels = {
+            "name": _("Name of Saas"),
             "url": _("URL"),
             "submitted_by": _("Submitted By"),
             "level_of_subscription": _("Level of Subscription"),
@@ -442,8 +458,6 @@ class ViewOldS32ApprovedRequestsForm(ModelForm):
             "date_manager_reviewed": _("Date Manager reviewed the request"),
             "manager_approved": _("Manager Approved"),
             "manager_denied": _("Manager Denied"),
-            "date_info_requested": _("Date Info Requested"),
-            "info_requested": _("Info Requested"),
             "date_sent_to_s_32_approver": _("Date Sent to S32 Approver"),
             "fund_center": _("Fund Center"),
             "approved_by": _("S32 Approver"),
@@ -456,13 +470,15 @@ class ViewOldS32ApprovedRequestsForm(ModelForm):
         self.helper = FormHelper()
         self.helper.form_id = "view_request_form"
         self.helper.form_class = "blueForms"
+        self.fields["date_info_requested"].label = False
+        self.fields['info_requested'].label = False
         self.helper.layout = Layout(
             Field("name", readonly=True),
             Field("url", readonly=True),
             Field("description", readonly=True),
             Field("cost", readonly=True),
-            Field("currency", readonly=True, style="height: auto;"),
-            Field("frequency", readonly=True, style="height: auto;"),
+            Field("currency", readonly=True, style="color:black; height:auto; background-color:#e9ecef; opacity:1;font-weight: inherit;font-color: inherit;"),
+            Field("frequency", readonly=True, style="color:black; height:auto; background-color:#e9ecef; opacity:1;font-weight: inherit;font-color: inherit;"),
             Field("units", readonly=True),
             Field("level_of_subscription", readonly=True),
             Field("number_of_users", readonly=True),
@@ -483,10 +499,10 @@ class ViewOldS32ApprovedRequestsForm(ModelForm):
                 readonly=True,
                 style="color:black; height:auto; background-color:#e9ecef; opacity:1; font-weight: inherit; font-color: inherit;",
             ),
-            Field("date_info_requested", readonly=True),
-            Field("info_requested", readonly=True),
+            Field("date_info_requested", readonly=True, hidden=True),
+            Field("info_requested", readonly=True, hidden=True), 
             Field("date_sent_to_s_32_approver", readonly=True),
-            Field("fund_center", readonly=True),
+            Field("fund_center", readonly=True, style="height:auto"),
             Field("approved_by", readonly=True, style="height:auto"),
             Button(
                 "cancel",
@@ -496,3 +512,9 @@ class ViewOldS32ApprovedRequestsForm(ModelForm):
                 onclick="history.back()",
             ),
         )
+        if self.instance.date_info_requested:
+            self.helper.layout[20] = Field("date_info_requested", readonly=True, hidden=False)
+            self.fields["date_info_requested"].label = "Date Info Requested"
+        if self.instance.info_requested:
+            self.helper.layout[21] = Field("info_requested", readonly=True, hidden=False)
+            self.fields['info_requested'].label = "Info Requested"

--- a/saas_app/internal_ops/tests.py
+++ b/saas_app/internal_ops/tests.py
@@ -211,7 +211,7 @@ class ViewS32RequestFormTest(TestCase):
     def test_name_label(self):
         form = ViewS32RequestForm()
         self.assertTrue(
-            form.fields["name"].label is None or form.fields["name"].label == "Name"
+            form.fields["name"].label is None or form.fields["name"].label == "Name of Saas"
         )
 
     # Test the url label of the form
@@ -379,7 +379,7 @@ class ViewPurchaseRequiredFormTest(TestCase):
     def test_name_label(self):
         form = ViewPurchaseRequiredForm()
         self.assertTrue(
-            form.fields["name"].label is None or form.fields["name"].label == "Name"
+            form.fields["name"].label is None or form.fields["name"].label == "Name of Saas"
         )
 
     # Test the url label of the form
@@ -547,7 +547,7 @@ class ViewOldPurchasedRequestsFormTest(TestCase):
     def test_name_label(self):
         form = ViewOldPurchasedRequestsForm()
         self.assertTrue(
-            form.fields["name"].label is None or form.fields["name"].label == "Name"
+            form.fields["name"].label is None or form.fields["name"].label == "Name of Saas"
         )
 
     # Test the url label of the form
@@ -796,7 +796,7 @@ class ViewOldS32ApprovedRequestsFormTest(TestCase):
     def test_name_label(self):
         form = ViewOldS32ApprovedRequestsForm()
         self.assertTrue(
-            form.fields["name"].label is None or form.fields["name"].label == "Name"
+            form.fields["name"].label is None or form.fields["name"].label == "Name of Saas"
         )
 
     # Test the url label of the form

--- a/saas_app/internal_ops/tests.py
+++ b/saas_app/internal_ops/tests.py
@@ -211,7 +211,8 @@ class ViewS32RequestFormTest(TestCase):
     def test_name_label(self):
         form = ViewS32RequestForm()
         self.assertTrue(
-            form.fields["name"].label is None or form.fields["name"].label == "Name of Saas"
+            form.fields["name"].label is None
+            or form.fields["name"].label == "Name of Saas"
         )
 
     # Test the url label of the form
@@ -379,7 +380,8 @@ class ViewPurchaseRequiredFormTest(TestCase):
     def test_name_label(self):
         form = ViewPurchaseRequiredForm()
         self.assertTrue(
-            form.fields["name"].label is None or form.fields["name"].label == "Name of Saas"
+            form.fields["name"].label is None
+            or form.fields["name"].label == "Name of Saas"
         )
 
     # Test the url label of the form
@@ -547,7 +549,8 @@ class ViewOldPurchasedRequestsFormTest(TestCase):
     def test_name_label(self):
         form = ViewOldPurchasedRequestsForm()
         self.assertTrue(
-            form.fields["name"].label is None or form.fields["name"].label == "Name of Saas"
+            form.fields["name"].label is None
+            or form.fields["name"].label == "Name of Saas"
         )
 
     # Test the url label of the form
@@ -796,7 +799,8 @@ class ViewOldS32ApprovedRequestsFormTest(TestCase):
     def test_name_label(self):
         form = ViewOldS32ApprovedRequestsForm()
         self.assertTrue(
-            form.fields["name"].label is None or form.fields["name"].label == "Name of Saas"
+            form.fields["name"].label is None
+            or form.fields["name"].label == "Name of Saas"
         )
 
     # Test the url label of the form

--- a/saas_app/internal_ops/views.py
+++ b/saas_app/internal_ops/views.py
@@ -183,36 +183,35 @@ def view_request(request, pk):
         saas_object = SaasRequest.objects.get(pk=pk)
         # initialize the instance to get teh id in the form
         form = ViewS32RequestForm(request.POST, instance=saas_object)
-        # if the save button was clicked
-        if request.POST.get("save"):
-            if form.is_valid():
-                # update the fund center and the approved by fields
-                if (
-                    form.cleaned_data["fund_center"] is not None
-                    and form.cleaned_data["approved_by"] is not None
-                ):
-                    saas_object.fund_center = form.cleaned_data["fund_center"]
-                    saas_object.approved_by = form.cleaned_data["approved_by"]
-                    saas_object.status = _("Waiting to be sent for S32 Approval")
-                    saas_object.internal_ops = Users.objects.get(user=request.user)
-
-                    try:
-                        # Save the data to the database
-                        saas_object = form.save()
-                        messages.success(request, _("The form was successfully saved."))
-                    except Exception as e:
-                        print(e)
-                        messages.error(
-                            request, _("There was an error saving the form.")
-                        )
-                else:
-                    messages.error(
-                        request, _("Please add the fund center and the approver.")
-                    )
-            return render(request, "internal_ops/view_request.html", {"form": form})
-        elif request.POST.get("send_for_s32_approval"):
+        # if the send for s32 approval button was clicked
+        if request.POST.get("send_for_s32_approval"):
             # update the status
             try:
+                if form.is_valid():
+                # update the fund center and the approved by fields
+                    if (
+                        form.cleaned_data["fund_center"] is not None
+                        and form.cleaned_data["approved_by"] is not None
+                        ):
+                        saas_object.fund_center = form.cleaned_data["fund_center"]
+                        saas_object.approved_by = form.cleaned_data["approved_by"]
+                        saas_object.status = _("Waiting to be sent for S32 Approval")
+                        saas_object.internal_ops = Users.objects.get(user=request.user)
+
+                        try:
+                            # Save the data to the database
+                            saas_object = form.save()
+                        except Exception as e:
+                            print(e)
+                            messages.error(
+                                request, _("There was an error adding the fund center or the approver.")
+                            )
+                    else:
+                        messages.error(
+                            request, _("Please add the fund center and the approver.")
+                        )
+                        return render(request, "internal_ops/view_request.html", {"form": form})
+
                 saas_object.status = _("Sent to S32 Approver for Approval")
                 saas_object.date_sent_to_s_32_approver = timezone.now()
                 if saas_object.internal_ops is None:
@@ -224,16 +223,6 @@ def view_request(request, pk):
                 messages.error(
                     request, _("There was an error updating the status of the form.")
                 )
-
-            # if the approver or fund center is not set, then return an error
-            if saas_object.fund_center is None or saas_object.approved_by is None:
-                messages.error(
-                    request,
-                    _(
-                        "Please add the fund center and the approver and then save the form."
-                    ),
-                )
-                return render(request, "internal_ops/view_request.html", {"form": form})
 
             # Email the S32 approver to review the form and the requestor that the form has been sent for s32 approval
             try:

--- a/saas_app/internal_ops/views.py
+++ b/saas_app/internal_ops/views.py
@@ -188,11 +188,11 @@ def view_request(request, pk):
             # update the status
             try:
                 if form.is_valid():
-                # update the fund center and the approved by fields
+                    # update the fund center and the approved by fields
                     if (
                         form.cleaned_data["fund_center"] is not None
                         and form.cleaned_data["approved_by"] is not None
-                        ):
+                    ):
                         saas_object.fund_center = form.cleaned_data["fund_center"]
                         saas_object.approved_by = form.cleaned_data["approved_by"]
                         saas_object.status = _("Waiting to be sent for S32 Approval")
@@ -204,13 +204,18 @@ def view_request(request, pk):
                         except Exception as e:
                             print(e)
                             messages.error(
-                                request, _("There was an error adding the fund center or the approver.")
+                                request,
+                                _(
+                                    "There was an error adding the fund center or the approver."
+                                ),
                             )
                     else:
                         messages.error(
                             request, _("Please add the fund center and the approver.")
                         )
-                        return render(request, "internal_ops/view_request.html", {"form": form})
+                        return render(
+                            request, "internal_ops/view_request.html", {"form": form}
+                        )
 
                 saas_object.status = _("Sent to S32 Approver for Approval")
                 saas_object.date_sent_to_s_32_approver = timezone.now()

--- a/saas_app/submit_request/forms.py
+++ b/saas_app/submit_request/forms.py
@@ -29,6 +29,7 @@ class SubmitRequestForm(ModelForm):
             "comments",
         ]
         labels = {
+            "name": _("Name of Saas"),
             "currency": _("Currency"),
             "frequency": _("Frequency"),
             "units": _("Units"),
@@ -70,7 +71,7 @@ class SubmitRequestForm(ModelForm):
                 readonly=True,
                 style="height: auto;",
             ),
-            "fund_center",
+            Field("fund_center", style="height: auto;"),
             Field("comments", rows="5"),
         )
         self.helper.add_input(
@@ -108,6 +109,7 @@ class ViewRequestForm(ModelForm):
             "comments",
         ]
         labels = {
+            "name": _("Name of Saas"),
             "currency": _("Currency"),
             "frequency": _("Frequency"),
             "units": _("Units"),
@@ -140,7 +142,7 @@ class ViewRequestForm(ModelForm):
                 readonly=True,
                 style="height:auto;",
             ),
-            "fund_center",
+            Field("fund_center", style="height: auto;"),
             Field("comments", rows="5"),
             Submit("save", _("Save changes")),
             Submit(
@@ -185,6 +187,7 @@ class ViewPrevRequestForm(ModelForm):
             "status",
         ]
         labels = {
+            "name": _("Name of Saas"),
             "status": _("Current status"),
             "currency": _("Currency"),
             "frequency": _("Frequency"),

--- a/saas_app/submit_request/forms.py
+++ b/saas_app/submit_request/forms.py
@@ -181,9 +181,6 @@ class ViewPrevRequestForm(ModelForm):
             "manager",
             "fund_center",
             "comments",
-            "date_manager_reviewed",
-            "manager_approved",
-            "manager_denied",
             "status",
         ]
         labels = {
@@ -195,9 +192,6 @@ class ViewPrevRequestForm(ModelForm):
             "duration": _("Duration"),
             "fund_center": _("Fund Center"),
             "comments": _("Comments"),
-            "date_manager_reviewed": _("Date manager reviewed the request"),
-            "manager_approved": _("Manager approved the request"),
-            "manager_denied": _("Manager denied the request"),
         }
 
     def __init__(self, *args, **kwargs):
@@ -238,9 +232,6 @@ class ViewPrevRequestForm(ModelForm):
                 style="color:black; height:auto; background-color:#e9ecef; opacity:1;font-weight: inherit;font-color: inherit;",
             ),
             Field("comments", readonly=True, rows="5"),
-            Field("date_manager_reviewed", readonly=True),
-            Field("manager_approved", readonly=True),
-            Field("manager_denied", readonly=True),
             Field("status", readonly=True),
             Button(
                 "cancel",

--- a/saas_app/submit_request/tests.py
+++ b/saas_app/submit_request/tests.py
@@ -128,7 +128,8 @@ class SubmitRequestFormTest(TestCase):
     def test_name_label(self):
         form = SubmitRequestForm()
         self.assertTrue(
-            form.fields["name"].label is None or form.fields["name"].label == "Name of Saas"
+            form.fields["name"].label is None
+            or form.fields["name"].label == "Name of Saas"
         )
 
     # Test the url label of the form

--- a/saas_app/submit_request/tests.py
+++ b/saas_app/submit_request/tests.py
@@ -128,7 +128,7 @@ class SubmitRequestFormTest(TestCase):
     def test_name_label(self):
         form = SubmitRequestForm()
         self.assertTrue(
-            form.fields["name"].label is None or form.fields["name"].label == "Name"
+            form.fields["name"].label is None or form.fields["name"].label == "Name of Saas"
         )
 
     # Test the url label of the form

--- a/saas_app/templates/approve/view_all_prev_requests.html
+++ b/saas_app/templates/approve/view_all_prev_requests.html
@@ -12,7 +12,7 @@
     <table class="table table-hover table-bordered">
       <thead>
         <tr>
-          <th scope="col">{% trans "Name" %}</th>
+          <th scope="col">{% trans "Name of Saas" %}</th>
           <th scope="col">{% trans "Description" %}</th>
           <th scope="col">{% trans "Url" %}</th>
           <th scope="col">{% trans "Cost" %}</th>

--- a/saas_app/templates/approve/view_all_requests.html
+++ b/saas_app/templates/approve/view_all_requests.html
@@ -12,7 +12,7 @@
       <table class="table table-hover table-bordered">
         <thead>
           <tr>
-            <th scope="col">{% trans "Name" %}</th>
+            <th scope="col">{% trans "Name of Saas" %}</th>
             <th scope="col">{% trans "Description" %}</th>
             <th scope="col">{% trans "Url" %}</th>
             <th scope="col">{% trans "Cost" %}</th>

--- a/saas_app/templates/detail.html
+++ b/saas_app/templates/detail.html
@@ -14,7 +14,7 @@
   </div>
   <div class="card-body">
     <h4 class="card-title">{% trans "Detailed information about the SAAS request" %}</h4>
-    <p class="card-text"><b>{% trans "Name:" %}</b> {{saas_request.name}} </p>
+    <p class="card-text"><b>{% trans "Name of Saas:" %}</b> {{saas_request.name}} </p>
     <p class="card-text"><b>{% trans "Description:" %}</b> {{saas_request.description}} </p>
     <p class="card-text"><b>{% trans "URL:" %}</b> {{saas_request.url}} </p>
     <p class="card-text"><b>{% trans "Cost:" %}</b> {{saas_request.cost}} </p>

--- a/saas_app/templates/index.html
+++ b/saas_app/templates/index.html
@@ -17,7 +17,7 @@
         <div class="card-body">
           <h5 class="card-title">{% trans "Software as a Service Request Form" %}</h5>
           <p class="card-text">{% trans "Please fill out this form if you would like to request the purchase of an unclassified software subscription service." %}</p>
-          <a href="submit_request" class="btn btn-primary" target="_blank">{% trans "Start" %}</a>
+          <a href="submit_request" class="btn btn-primary">{% trans "Start" %}</a>
         </div>
       </div>
       <br>
@@ -28,7 +28,7 @@
         <div class="card-body">
           <h5 class="card-title">{% trans "View your submitted requests" %}</h5>
           <p class="card-text">{% trans "Click here to view all of your submitted SAAS requests." %}</p>
-          <a href="submit_request/view" class="btn btn-primary" target="_blank">{% trans "Start" %}</a>
+          <a href="submit_request/view" class="btn btn-primary">{% trans "Start" %}</a>
         </div>
       </div>
       <br>
@@ -40,7 +40,7 @@
       <div class="card-body">
         <h5 class="card-title">{% trans "Manager - Approve/Deny requests" %}</h5>
         <p class="card-text">{% trans "For manager, click here to approve/deny existing requests." %}</p>
-        <a href="approve/view" class="btn btn-primary" target="_blank">{% trans "Start" %}</a>
+        <a href="approve/view" class="btn btn-primary">{% trans "Start" %}</a>
       </div>
     </div>
     <br>
@@ -51,7 +51,7 @@
         <div class="card-body">
           <h5 class="card-title">{% trans "View your previously reviewed requests" %}</h5>
           <p class="card-text">{% trans "Click here to view all requests that you have previously reviewed." %}</p>
-          <a href="approve/view_prev" class="btn btn-primary" target="_blank">{% trans "Start" %}</a>
+          <a href="approve/view_prev" class="btn btn-primary">{% trans "Start" %}</a>
         </div>
       </div>
     <br>
@@ -63,7 +63,7 @@
       <div class="card-body">
         <h5 class="card-title">{% trans "View requests that need your action" %}</h5>
         <p class="card-text">{% trans "For internal ops, click here to view requests that require action, such as selecting S32 approver or recording a purchase." %}</p>
-        <a href="internal_ops/view" class="btn btn-primary" target="_blank">{% trans "Start" %}</a>
+        <a href="internal_ops/view" class="btn btn-primary">{% trans "Start" %}</a>
       </div>
     </div>
     <br>
@@ -74,7 +74,7 @@
         <div class="card-body">
           <h5 class="card-title">{% trans "View your previously reviewed requests" %}</h5>
           <p class="card-text">{% trans "Click here to view all requests that you have previously reviewed." %}</p>
-          <a href="internal_ops/view_prev" class="btn btn-primary" target="_blank">{% trans "Start" %}</a>
+          <a href="internal_ops/view_prev" class="btn btn-primary">{% trans "Start" %}</a>
         </div>
       </div>
     <br>
@@ -86,7 +86,7 @@
       <div class="card-body">
         <h5 class="card-title">{% trans "Approve/Deny requests" %}</h5>
         <p class="card-text">{% trans "For S32 Approver - click here to approve or deny requests." %}</p>
-        <a href="approve/view_s32" class="btn btn-primary" target="_blank">{% trans "Start" %}</a>
+        <a href="approve/view_s32" class="btn btn-primary">{% trans "Start" %}</a>
       </div>
     </div>
     <br>
@@ -97,7 +97,7 @@
       <div class="card-body">
       <h5 class="card-title">{% trans "View your previously reviewed requests" %}</h5>
         <p class="card-text">{% trans "Click here to view all requests that you have previously reviewed." %}</p>
-        <a href="approve/view_s32_prev" class="btn btn-primary" target="_blank">{% trans "Start" %}</a>
+        <a href="approve/view_s32_prev" class="btn btn-primary">{% trans "Start" %}</a>
       </div>
       </div>
     {% elif role == "Administrator" %}
@@ -108,7 +108,7 @@
       <div class="card-body">
         <h5 class="card-title">{% trans "Change User's Attributes" %}</h5>
         <p class="card-text">{% trans "Add/change user data." %}</p>
-        <a href="administration/view" class="btn btn-primary" target="_blank">{% trans "Start" %}</a>
+        <a href="administration/view" class="btn btn-primary">{% trans "Start" %}</a>
       </div>
     </div>
     <br>

--- a/saas_app/templates/index.html
+++ b/saas_app/templates/index.html
@@ -7,7 +7,7 @@
 
 {% block content %}
 {% if user.is_authenticated %}
-    <h1>{% trans "Welcome" %} {{user}}!</h1>
+    <h1>{% trans "Welcome" %} {{user|capfirst}}!</h1>
     <p>{% trans "What do you want to do today?" %}</p></br>
     {% if role == "Requestor" %}
       <div class="card">

--- a/saas_app/templates/internal_ops/view_all_prev_requests.html
+++ b/saas_app/templates/internal_ops/view_all_prev_requests.html
@@ -44,7 +44,7 @@
   <table class="table table-hover table-bordered">
     <thead>
         <tr>
-          <th scope="col">{% trans "Name" %}</th>
+          <th scope="col">{% trans "Name of Saas" %}</th>
           <th scope="col">{% trans "Description" %}</th>
           <th scope="col">{% trans "Url" %}</th>
           <th scope="col">{% trans "Cost" %}</th>

--- a/saas_app/templates/internal_ops/view_all_prev_requests.html
+++ b/saas_app/templates/internal_ops/view_all_prev_requests.html
@@ -12,7 +12,7 @@
   <table class="table table-hover table-bordered">
     <thead>
         <tr>
-          <th scope="col">{% trans "Name" %}</th>
+          <th scope="col">{% trans "Name of Saas" %}</th>
           <th scope="col">{% trans "Description" %}</th>
           <th scope="col">{% trans "Url" %}</th>
           <th scope="col">{% trans "Cost" %}</th>

--- a/saas_app/templates/internal_ops/view_all_requests.html
+++ b/saas_app/templates/internal_ops/view_all_requests.html
@@ -45,7 +45,7 @@
   <table class="table table-hover table-bordered">
     <thead>
         <tr>
-          <th scope="col">{% trans "Name" %}</th>
+          <th scope="col">{% trans "Name of Saas" %}</th>
           <th scope="col">{% trans "Description" %}</th>
           <th scope="col">{% trans "Url" %}</th>
           <th scope="col">{% trans "Cost" %}</th>

--- a/saas_app/templates/internal_ops/view_all_requests.html
+++ b/saas_app/templates/internal_ops/view_all_requests.html
@@ -12,7 +12,7 @@
       <table class="table table-hover table-bordered">
         <thead>
           <tr>
-            <th scope="col">{% trans "Name" %}</th>
+            <th scope="col">{% trans "Name of Saas" %}</th>
             <th scope="col">{% trans "Description" %}</th>
             <th scope="col">{% trans "Url" %}</th>
             <th scope="col">{% trans "Cost" %}</th>

--- a/saas_app/templates/request/saas_request.html
+++ b/saas_app/templates/request/saas_request.html
@@ -16,8 +16,6 @@
     In this form, you may select your current supervisor to approve of this purchase. Internal Ops will then get fund centre manager financial approval.
     
     For further information or guidance on subscription services, please talk to the Internal Operations team. {% endblocktrans %}</p>
-<p><a href="https://docs.google.com/document/d/1Vc3cKhlCvakHylmKQQEHc44tffLO7lozQ74aHHRQq2o/edit#heading=h.49a16cu36wcw">{% trans "Guide to requesting low-dollar value unclassified software subscription services" %}</a></p>   
-<a href="https://docs.google.com/spreadsheets/d/1IfwCl6IkeD4v-OfB90XpeoS26IOdYW_sfQxRhvavc1E/edit#gid=0">{% trans "CDS Subscription Services - Billing and Admin" %}</a></p>
 <form method="post" novalidate>
         {% csrf_token %}
         {% crispy form %}

--- a/saas_app/templates/request/view_all_requests.html
+++ b/saas_app/templates/request/view_all_requests.html
@@ -14,7 +14,7 @@
         <table class="table table-hover table-bordered">
           <thead>
               <tr>
-                <th scope="col">{% trans "Name" %}</th>
+                <th scope="col">{% trans "Name of Saas" %}</th>
                 <th scope="col">{% trans "Description" %}</th>
                 <th scope="col">{% trans "Url" %}</th>
                 <th scope="col">{% trans "Cost" %}</th>


### PR DESCRIPTION
# Summary | Résumé

The following changes were made:

1. The links to the documents when you submit the form were taken off
2. Links are no longer opening on new tabs
3. For the internal ops view, the submit button for S32 approval now saves the form and notifies the user if the fund centre or S32 approver is not added.
4. The Fund center box was made bigger to fit the data.
5. The info requested and date requested fields only show up if there is data. 
6. The Name field in the saas request form was renamed to Name of Saas 
7. The currency and frequency were made read only when viewing a submitted saas.  