### PR TITLE
Removing sudo from command since it is not needed

### DIFF
--- a/saas_app/bin/initialize.sh
+++ b/saas_app/bin/initialize.sh
@@ -85,7 +85,7 @@ touch logs/cronjob.log
 # Add the crontab entry so that we can run it every day
 echo "Starting cron service"
 # Start the cron service
-sudo /etc/init.d/cron start
+/etc/init.d/cron start
 # Add the crontab entry
 echo "Setting up crontab"
 python manage.py crontab remove 


### PR DESCRIPTION
# Summary | Résumé

Removing sudo from starting the cron daemon since it is not needed and generates an errro. 