### PR TITLE
Adding env access to crontab, increasing fargate CPU and decreasing ECS task to 1

### DIFF
--- a/saas_app/saas_app/settings.py
+++ b/saas_app/saas_app/settings.py
@@ -222,10 +222,18 @@ SESSION_ENGINE = "django.contrib.sessions.backends.db"
 USE_X_FORWARDED_HOST = True
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
+# envs = []
+# for envkey in os.environ.keys():
+#     envs.append(envkey + '=' + os.environ[envkey])
+# CRONTAB_COMMAND_PREFIX = 'env $(echo ' + '\n'.join(envs) + ' | xargs)'
+
+# CRONTAB_COMMAND_PREFIX = ("AZURE_CLIENT_ID=" + os.environ.get('AZURE_CLIENT_ID'))
+# ENV_FILE = os.path.join(BASE_DIR, ".env")
+
 # Configure the crontab to run at 5am UTC every day
 CRONJOBS = [
     (
-        "0 5 * * *",
+        "0 5 * * * (source .env || true) &&",
         "manage_saas.views.daily_import_sentinel_data",
         ">>" + os.path.join(BASE_DIR, "logs/cronjob.log" + " 2>&1"),
     )

--- a/saas_app/saas_app/settings.py
+++ b/saas_app/saas_app/settings.py
@@ -222,14 +222,6 @@ SESSION_ENGINE = "django.contrib.sessions.backends.db"
 USE_X_FORWARDED_HOST = True
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
-# envs = []
-# for envkey in os.environ.keys():
-#     envs.append(envkey + '=' + os.environ[envkey])
-# CRONTAB_COMMAND_PREFIX = 'env $(echo ' + '\n'.join(envs) + ' | xargs)'
-
-# CRONTAB_COMMAND_PREFIX = ("AZURE_CLIENT_ID=" + os.environ.get('AZURE_CLIENT_ID'))
-# ENV_FILE = os.path.join(BASE_DIR, ".env")
-
 # Configure the crontab to run at 5am UTC every day
 CRONJOBS = [
     (

--- a/terragrunt/aws/ecs/ecs.tf
+++ b/terragrunt/aws/ecs/ecs.tf
@@ -44,7 +44,7 @@ resource "aws_ecs_service" "saas-procurement-app-service" {
   name             = "saas_procurement-service"
   cluster          = aws_ecs_cluster.saas_procurement.id
   task_definition  = aws_ecs_task_definition.saas_procurement.arn
-  desired_count    = 2
+  desired_count    = 1
   launch_type      = "FARGATE"
   platform_version = "1.4.0"
   propagate_tags   = "SERVICE"

--- a/terragrunt/aws/ecs/inputs.tf
+++ b/terragrunt/aws/ecs/inputs.tf
@@ -27,7 +27,7 @@ variable "ecr_repository_url" {
 variable "fargate_cpu" {
   description = "Fargate CPU units"
   type        = number
-  default     = 1024 
+  default     = 1024
 }
 
 variable "fargate_memory" {

--- a/terragrunt/aws/ecs/inputs.tf
+++ b/terragrunt/aws/ecs/inputs.tf
@@ -27,7 +27,7 @@ variable "ecr_repository_url" {
 variable "fargate_cpu" {
   description = "Fargate CPU units"
   type        = number
-  default     = 512
+  default     = 1024 
 }
 
 variable "fargate_memory" {


### PR DESCRIPTION
# Summary | Résumé

Gave access to the environment variables of my cron job. The ECS tasks were running out of CPU and thus failing, so I had to increase the CPU cycles. To counteract the cost of this (approximately $30 increase in cost/month), I decreased the ECS task to 1. With the proceeding changes, the cost should be the same. 