### PR TITLE
Changing CPU (again)

### DIFF
--- a/terragrunt/aws/ecs/inputs.tf
+++ b/terragrunt/aws/ecs/inputs.tf
@@ -27,7 +27,7 @@ variable "ecr_repository_url" {
 variable "fargate_cpu" {
   description = "Fargate CPU units"
   type        = number
-  default     = 512 
+  default     = 512
 }
 
 variable "fargate_memory" {

--- a/terragrunt/aws/ecs/inputs.tf
+++ b/terragrunt/aws/ecs/inputs.tf
@@ -27,7 +27,7 @@ variable "ecr_repository_url" {
 variable "fargate_cpu" {
   description = "Fargate CPU units"
   type        = number
-  default     = 1024
+  default     = 512 
 }
 
 variable "fargate_memory" {


### PR DESCRIPTION
# Summary | Résumé

Uggh... So my terraform apply failed (https://github.com/cds-snc/saas-procurement/actions/runs/5648087651/job/15299536819) because I can't have an ECS task with 1G cpu and 1GB memory - https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html. I would have to increase the memory to 2GB but as this will increase the cost and I have minimized the ecs tasks to 1, I am hoping that this will be sufficient.  Sorry, hopefully this will be the last one!