### PR TITLE
Iam Role for ECS exec commands

### DIFF
--- a/terragrunt/aws/iam/iam.tf
+++ b/terragrunt/aws/iam/iam.tf
@@ -23,10 +23,35 @@ data "aws_iam_policy_document" "saas_procurement_ssm" {
   }
 }
 
+data "aws_iam_policy_document" "saas_procurement_ecs_exec" {
+  statement {
+    sid    = "AllowECSExec"
+    effect = "Allow"
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel"
+    ]
+    resources = ["*"]
+  }
+}
+
 resource "aws_iam_policy" "saas_procurement_ssm" {
   name        = "${var.product_name}_Ssm"
   description = "Allow retrieval of ssm data"
   policy      = data.aws_iam_policy_document.saas_procurement_ssm.json
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+}
+
+resource "aws_iam_policy" "saas_procurement_ecs_exec" {
+  name        = "${var.product_name}_ecs_exec"
+  description = "Allow connection to the ecs task running the container"
+  policy      = data.aws_iam_policy_document.saas_procurement_ecs_exec.json
 
   tags = {
     CostCentre = var.billing_code
@@ -69,3 +94,7 @@ resource "aws_iam_role_policy_attachment" "saas_procurement_ssm" {
   role       = aws_iam_role.saas_procurement_task.name
 }
 
+resource "aws_iam_role_policy_attachment" "saas_procurement_ecs_exec" {
+  policy_arn = aws_iam_policy.saas_procurement_ecs_exec.arn
+  role       = aws_iam_role.saas_procurement_task.name
+}


### PR DESCRIPTION
# Summary | Résumé

Added IAM role so that we can use Amazon ECS exec for debugging purposes. More information can be found here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html
Let me know if granting this is not secure or if there is a better way to do it. It is super useful though, when trying to debug your container in ECS. 