### PR TITLE
Fixing up generating Docker SBOM platform

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -101,7 +101,7 @@ jobs:
         with:
           docker_image: "${{ env.REGISTRY }}:latest"
           dockerfile_path: "saas_app/Dockerfile"
-          platform: "linux/arm64"
+          platform: "linux/amd64"
           sbom_name: "saas_procurement"
           token: "${{ secrets.GITHUB_TOKEN }}"
 


### PR DESCRIPTION
# Summary | Résumé

Closes #237. 

Fixing up platform linux platform SBOM architecture to be amd64 from arm64. This would fix up the issue that is displayed here - https://github.com/cds-snc/saas-procurement/actions/runs/6006361213/job/16290758265
