### PR TITLE
Removing the serverless instance_class to be the default db.t3.medium

### DIFF
--- a/terragrunt/aws/rds/rds.tf
+++ b/terragrunt/aws/rds/rds.tf
@@ -8,12 +8,10 @@ module "rds_cluster" {
   database_name  = var.database_name
   engine         = "aurora-postgresql"
   engine_version = "14.6"
+  instance_class = "db.t3.medium"
   instances      = var.database_instances_count
   username       = var.database_username
   password       = var.database_password
-
-  serverless_min_capacity = 1.0
-  serverless_max_capacity = 1.0
 
   backup_retention_period = 14
   preferred_backup_window = "02:00-04:00"

--- a/terragrunt/aws/rds/rds.tf
+++ b/terragrunt/aws/rds/rds.tf
@@ -9,7 +9,6 @@ module "rds_cluster" {
   engine         = "aurora-postgresql"
   engine_version = "14.6"
   instances      = var.database_instances_count
-  instance_class = "db.serverless"
   username       = var.database_username
   password       = var.database_password
 


### PR DESCRIPTION
# Summary | Résumé

In order to save money, I am reverting to the default db.t3.medium instance_class as opposed to the serverless one as it is 3 times more expensive 😱 

By removing the instance class, we are defaulting to the terraform-modules rds instance class of db.t3.medium