### PR TITLE
Adding backstage catalog info config file to be able to read github data to Backstage

### DIFF
--- a/catalog-info.yml
+++ b/catalog-info.yml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: saas-procurement
+  annotations:
+    github.com/project-slug: cds-snc/saas-procurement
+spec:
+  type: other
+  lifecycle: unknown


### PR DESCRIPTION
# Summary | Résumé

Add backstage config file to the saas procurement app to be able to ingest github data into Backstage. 