### PR TITLE
Expire session after 1 hour

### DIFF
--- a/saas_app/saas_app/settings.py
+++ b/saas_app/saas_app/settings.py
@@ -253,3 +253,11 @@ LOGGING = {
         },
     },
 }
+
+# # Session Timeout settings
+# SESSION_EXPIRE_SECONDS = 50  # 300 seconds = 5 minutes
+
+SESSION_COOKIE_AGE = 40 #60 * 60 * 24  # 24 hours
+# # expire the session after the last activity, otherwise it will expire the session after 5 minutes from the start of the session. 
+ #SESSION_EXPIRE_AFTER_LAST_ACTIVITY = True
+

--- a/saas_app/saas_app/settings.py
+++ b/saas_app/saas_app/settings.py
@@ -254,10 +254,6 @@ LOGGING = {
     },
 }
 
-# # Session Timeout settings
-# SESSION_EXPIRE_SECONDS = 50  # 300 seconds = 5 minutes
-
-SESSION_COOKIE_AGE = 40 #60 * 60 * 24  # 24 hours
-# # expire the session after the last activity, otherwise it will expire the session after 5 minutes from the start of the session. 
- #SESSION_EXPIRE_AFTER_LAST_ACTIVITY = True
+# Change the session cookie age to 1 hour. 
+SESSION_COOKIE_AGE = 60 * 60 # 1 hour 
 


### PR DESCRIPTION
# Summary | Résumé

Expire the session after 1 hour. By default, Django expires sessions after 24 hours so we need to change this to be a shorter time frame. 