### PR TITLE
Fixing modals that broke due to upgrade of Bootstrap 5

### DIFF
--- a/saas_app/internal_ops/forms.py
+++ b/saas_app/internal_ops/forms.py
@@ -134,9 +134,9 @@ class ViewS32RequestForm(ModelForm):
                 _("Request Additional Information"),
                 css_id="submit",
                 css_class="btn btn-primary",
-                data_toggle="modal",
-                data_target="#request_info_modal",
-                data_dismiss="modal",
+                data_bs_toggle="modal",
+                data_bs_target="#request_info_modal",
+                data_bs_dismiss="modal",
             ),
             # hide the purchase button for now. It will be shown if the request is approved by an s32 approver.
             Button(
@@ -144,9 +144,9 @@ class ViewS32RequestForm(ModelForm):
                 _("Record Purchase Information"),
                 css_id="submit",
                 css_class="btn btn-primary",
-                data_toggle="modal",
-                data_target="#purchase_modal",
-                data_dismiss="modal",
+                data_bs_toggle="modal",
+                data_bs_target="#purchase_modal",
+                data_bs_dismiss="modal",
                 hidden=True,
             ),
             Button(
@@ -169,9 +169,9 @@ class ViewS32RequestForm(ModelForm):
                 _("Record Purchase Information"),
                 css_id="submit",
                 css_class="btn btn-primary",
-                data_toggle="modal",
-                data_target="#purchase_modal",
-                data_dismiss="modal",
+                data_bs_toggle="modal",
+                data_bs_target="#purchase_modal",
+                data_bs_dismiss="modal",
             )
         # unhide the date requested and information requested if there is data associated with those fields.
         if self.instance.date_info_requested is not None:
@@ -311,18 +311,18 @@ class ViewPurchaseRequiredForm(ModelForm):
                 _("Request Additional Information"),
                 css_id="submit",
                 css_class="btn btn-primary",
-                data_toggle="modal",
-                data_target="#request_info_modal",
-                data_dismiss="modal",
+                data_bs_toggle="modal",
+                data_bs_target="#request_info_modal",
+                data_bs_dismiss="modal",
             ),
             Button(
                 "purchase",
                 _("Record Purchase Information"),
                 css_id="submit",
                 css_class="btn btn-primary",
-                data_toggle="modal",
-                data_target="#purchase_modal",
-                data_dismiss="modal",
+                data_bs_toggle="modal",
+                data_bs_target="#purchase_modal",
+                data_bs_dismiss="modal",
             ),
             Button(
                 "cancel",

--- a/saas_app/templates/internal_ops/view_request.html
+++ b/saas_app/templates/internal_ops/view_request.html
@@ -20,8 +20,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="request_info_label">{% trans "New message to requestor" %}</h5>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
+         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </button>
       </div>
       <div class="modal-body">
@@ -32,7 +31,7 @@
             <textarea class="form-control" name="info_requested" id="info-requested" rows="7"></textarea>
           </div>
           <div class="modal-footer">
-          <button type="button" class="btn btn-secondary" data-dismiss="modal">{% trans "Close" %}</button>
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans "Close" %}</button>
           <button type="submit" class="btn btn-primary" name="submit" Value="Submit">{% trans "Send message" %}</button>
           </div>
         </form>
@@ -46,8 +45,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="exampleModalLabel">{% trans "Record Purchase Information" %}</h5>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </button>
       </div>
       <div class="modal-body">
@@ -74,7 +72,7 @@
             <textarea class="form-control" name="purchase-notes" id="purchase-notes"></textarea>
           </div>
            <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" data-dismiss="modal">{% trans "Close" %}</button>
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans "Close" %}</button>
             <button type="submit" class="btn btn-primary" name="submit" Value="Submit">{% trans "Save" %}</button>
           </div>
         </form>


### PR DESCRIPTION

# Summary | Résumé

In Bootstrap 5, there have been some changes to the way the modals were named/created and this PR fixes those difference. The reason why the modals broke in the first place was due to the fact that we were previously using Bootstrap 4 and now we are using Bootsrap 5. The modals look like this:

<img width="584" alt="Screenshot 2024-01-05 at 1 07 30 PM" src="https://github.com/cds-snc/saas-procurement/assets/85905333/ffdf519e-c35d-40d4-9cc6-325addfa5df7">
<img width="584" alt="Screenshot 2024-01-05 at 1 07 03 PM" src="https://github.com/cds-snc/saas-procurement/assets/85905333/dfdf49a0-0cc8-4e42-a84e-cb84ab3f89ff">
