### PR TITLE
Upgrading setuptools to latest version to avoid security vulnerability

### DIFF
--- a/saas_app/Dockerfile
+++ b/saas_app/Dockerfile
@@ -15,8 +15,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /saas_app
 COPY requirements.txt /saas_app/
 RUN pip install --no-cache-dir --upgrade pip \
-	&& pip install --upgrade setuptools \
-	&& pip install --no-cache-dir -r requirements.txt
+  && pip install --upgrade setuptools \
+  && pip install --no-cache-dir -r requirements.txt
 
 # Copy the rest of the application
 COPY . /saas_app/

--- a/saas_app/Dockerfile
+++ b/saas_app/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /saas_app
 COPY requirements.txt /saas_app/
 RUN pip install --no-cache-dir --upgrade pip \
-  && pip install --no-cache-dir -r requirements.txt
+	&& pip install --upgrade setuptools \
+	&& pip install --no-cache-dir -r requirements.txt
 
 # Copy the rest of the application
 COPY . /saas_app/


### PR DESCRIPTION
# Summary | Résumé

Upgrading setup tools to latest version in order to avoid the security vulnerability listed here - https://github.com/cds-snc/saas-procurement/security/dependabot/5

After upgrade, the current version is listed below:
![Screenshot 2024-01-11 at 2 41 50 PM](https://github.com/cds-snc/saas-procurement/assets/85905333/2b5bb9bc-aea5-4004-8565-65f7d4138589)
